### PR TITLE
Update alt text for Hero image to improve accessibility

### DIFF
--- a/src/sections/Hero.astro
+++ b/src/sections/Hero.astro
@@ -5,7 +5,7 @@
     >
       <img
         src="/images/lolalolitaland-hero.webp"
-        alt="Fotografía de una joven recostada, ques Lola Lolita, sobre la arena con una cola de sirena azul, frente a una piscina con toboganes rosas en un entorno tropical, con el texto ‘Lola Lolita Land’ en la parte superior."
+        alt="Fotografía de Lola Lolita recostada sobre la arena con una cola de sirena azul. Detrás, una piscina con toboganes rosas en un entorno tropical. En la parte superior de la imagen, se lee el texto ‘Lola Lolita Land’."
       />
     </div>
     <div


### PR DESCRIPTION
Se ha cambiado el alt de la imagen usada en Hero.astro. En el alt antiguo había un error "**ques** Lola Lolita".

Antiguo:
```
Fotografía de una joven recostada, ques Lola Lolita, sobre la arena con una cola de sirena azul, frente a una piscina con toboganes rosas en un entorno tropical, con el texto ‘Lola Lolita Land’ en la parte superior.
```

Nuevo:
```
Fotografía de Lola Lolita recostada sobre la arena con una cola de sirena azul. Detrás, una piscina con toboganes rosas en un entorno tropical. En la parte superior de la imagen, se lee el texto ‘Lola Lolita Land’.
```