### PR TITLE
Eliminacion de Carets en package.json y pnpm-lock.yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@fontsource/poppins": "^5.2.5",
-    "@tailwindcss/vite": "^4.0.9",
-    "astro": "^5.4.2",
-    "leaflet": "^1.9.4",
-    "tailwindcss": "^4.0.9"
+    "@fontsource/poppins": "5.2.5",
+    "@tailwindcss/vite": "4.0.9",
+    "astro": "5.4.2",
+    "leaflet": "1.9.4",
+    "tailwindcss": "4.0.9"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,19 +9,19 @@ importers:
   .:
     dependencies:
       '@fontsource/poppins':
-        specifier: ^5.2.5
+        specifier: 5.2.5
         version: 5.2.5
       '@tailwindcss/vite':
-        specifier: ^4.0.9
+        specifier: 4.0.9
         version: 4.0.9(vite@6.2.0(jiti@2.4.2)(lightningcss@1.29.1))
       astro:
-        specifier: ^5.4.2
+        specifier: 5.4.2
         version: 5.4.2(jiti@2.4.2)(lightningcss@1.29.1)(rollup@4.34.9)(typescript@5.8.2)
       leaflet:
-        specifier: ^1.9.4
+        specifier: 1.9.4
         version: 1.9.4
       tailwindcss:
-        specifier: ^4.0.9
+        specifier: 4.0.9
         version: 4.0.9
 
 packages:


### PR DESCRIPTION
Multiples veces midu ha dejado en claro, lo recomendable que es eliminar las carets en el **package.json** para evitar bugs con futuras actualizaciones de dependencias.

Se uso `pnpm install` para actualizar las dependencias en **pnpm-lock.yaml**