### PR TITLE
Desactivar zoom con scroll y arrastrar en LeafletMap; habilitar interactividad al hacer clic

### DIFF
--- a/src/components/LeafletMap.astro
+++ b/src/components/LeafletMap.astro
@@ -46,10 +46,19 @@ const {
           Number(this.dataset.longitude),
         ]
 
-        var map = window.L.map(this.dataset.container).setView(
+        var map = window.L.map(this.dataset.container, {
+          scrollWheelZoom: false, // Desactivar zoom con scroll
+          dragging: false // Desactivar arrastrar
+        }).setView(
           latlng,
           Number(this.dataset.zoom)
         )
+
+        // Activar interactividad al hacer clic
+        map.once("click", function () {
+          map.scrollWheelZoom.enable();
+          map.dragging.enable();
+        });
 
         window.L.tileLayer(this.dataset.tiles, {
           attribution: this.dataset.attribution,


### PR DESCRIPTION
Para evitar al hacer scroll dentro de la página y que acabes haciendo zoom-out en el mapa, hasta que no hagas clic en el mapa no funciona la rueda del ratón, y si estás en el móvil, para evitar lo mismo pero con el drag, hasta que no hagas clic no funcionará el drag.