### PR TITLE
FIX(TICKET): ajustar contenedor

### DIFF
--- a/src/sections/Tickets.astro
+++ b/src/sections/Tickets.astro
@@ -2,17 +2,19 @@
 import Marquee from "@/components/Marquee.astro"
 ---
 
-<div class="w-[110%] -rotate-3 bg-theme-green-light text-white -ml-2">
-  <Marquee
-    content={[
-      "Entradas",
-      "Entradas",
-      "Entradas",
-      "Entradas",
-      "Entradas",
-      "Entradas",
-      "Entradas",
-      "Entradas",
-    ]}
-  />
+<div class="w-full overflow-hidden relative">
+  <div class="w-[110%] -rotate-3 bg-theme-green-light text-white -ml-2 mt-[3%] mx-auto">
+    <Marquee
+      content={[
+        "Entradas",
+        "Entradas",
+        "Entradas",
+        "Entradas",
+        "Entradas",
+        "Entradas",
+        "Entradas",
+        "Entradas",
+      ]}
+    />
+  </div>
 </div>


### PR DESCRIPTION
Arreglar error con el width=110%, dejaba un espacio en la versión móvil en las demás secciones.

Antes 🔴 
![image](https://github.com/user-attachments/assets/ad366e5a-52be-487f-8389-a302620a381a)

Ahora 🟢 
![image](https://github.com/user-attachments/assets/337dc1fd-5720-4f45-aada-afcef4874afb)
