### PR TITLE
feat: add hover scale and transition

### DIFF
--- a/src/sections/Hero.astro
+++ b/src/sections/Hero.astro
@@ -2,7 +2,7 @@
   <div
     class="grid grid-cols-1 md:grid-cols-5 md:grid-rows-4 gap-4 max-w-5xl mx-auto"
   >
-    <div class="md:col-span-4 md:row-span-3 aspect-video rounded-2xl relative">
+    <div class="md:col-span-4 md:row-span-3 aspect-video rounded-2xl relative hover:scale-101 transition">
       <img
         class="rounded-2xl z-10 relative"
         src="/images/lolalolitaland-hero.webp"
@@ -15,19 +15,19 @@
       />
     </div>
     <div
-      class="md:row-span-2 md:col-start-5 bg-primary rounded-2xl text-4xl text-center text-white font-black justify-center items-center flex"
+      class="md:row-span-2 md:col-start-5 bg-primary rounded-2xl text-4xl text-center text-white font-black justify-center items-center flex hover:scale-101 transition"
     >
       <div class="-rotate-3 flex flex-col">
         <span>14 & 15</span><span>de junio</span>
       </div>
     </div>
     <div
-      class="md:row-span-2 md:col-start-5 row-start-3 bg-primary rounded-2xl text-4xl text-center text-white font-black justify-center items-center flex"
+      class="md:row-span-2 md:col-start-5 row-start-3 bg-primary rounded-2xl text-4xl text-center text-white font-black justify-center items-center flex hover:scale-101 transition"
     >
       <span class="-rotate-3 flex flex-col"> Compra tus entradas </span>
     </div>
     <div
-      class="md:col-span-2 md:row-start-4 bg-primary rounded-2xl relative overflow-hidden"
+      class="md:col-span-2 md:row-start-4 bg-primary rounded-2xl relative overflow-hidden hover:scale-101 transition"
     >
       <a href="/#mapa">
         <img
@@ -38,7 +38,7 @@
       </a>
     </div>
     <div
-      class="md:col-span-2 md:col-start-3 row-start-4 bg-primary rounded-2xl"
+      class="md:col-span-2 md:col-start-3 row-start-4 bg-primary rounded-2xl hover:scale-101 transition"
     >
       5
     </div>


### PR DESCRIPTION
Agregué un ligero efecto de hover a cada ítem del grid, aumentando su tamaño en 1% con una suave transición.
> No añadí el `cursor-pointer` para evitar redundancia en caso de que los demás ítems también tengan enlaces.

![HoverLite](https://github.com/user-attachments/assets/3c631869-a4b2-4114-a365-708b35e404ed)
