### PR TITLE
refactor: LeafletMap

### DIFF
--- a/src/components/LeafletMap.astro
+++ b/src/components/LeafletMap.astro
@@ -1,79 +1,63 @@
 ---
-import "leaflet/dist/leaflet.css";
+import "leaflet/dist/leaflet.css"
 
 export interface Props {
-  latitude: number;
-  longitude: number;
-  zoom: number;
-  /** ID del elemento contenedor */
-  container: string;
+  latitude: number
+  longitude: number
+  zoom: number
   /** URL del tileLayer, ver: https://leafletjs.com/reference.html#tilelayer */
-  tileLayer: string;
+  tileLayer: string
   /** Atribución requerida por la mayoría de tile servers */
-  attribution: string;
-  containerstyle?: string;
+  attribution: string
 }
 
-const {
-  latitude,
-  longitude,
-  zoom,
-  container,
-  tileLayer,
-  attribution,
-  containerstyle = "height: 61.8vh",
-} = Astro.props;
+const { latitude, longitude, zoom, container, tileLayer, attribution } = Astro.props
 ---
 
 <leaflet-map
+  class="block h-full"
   data-latitude={latitude}
   data-longitude={longitude}
   data-zoom={zoom}
   data-container={container}
   data-tiles={tileLayer}
   data-attribution={attribution}
-  data-containerstyle={containerstyle}
 >
-  <div id={container} style={containerstyle}></div>
 </leaflet-map>
 
 <script>
-  import "leaflet";
+  import L from "leaflet"
 
-  if (!window.customElements.get("leaflet-map")) {
-    class LeafletMap extends HTMLElement {
-      connectedCallback() {
-        const { latitude, longitude, zoom, container, tiles, attribution } =
-          this.dataset;
-        const latlng = [Number(latitude), Number(longitude)];
+  class LeafletMap extends HTMLElement {
+    connectedCallback() {
+      const { latitude, longitude, zoom, tiles, attribution } = this.dataset
+      const latlng = [Number(latitude), Number(longitude)]
 
-        const map = window.L.map(container, {
-          scrollWheelZoom: false,
-          dragging: false,
-        }).setView(latlng, Number(zoom));
+      const map = L.map(this, {
+        scrollWheelZoom: false,
+        dragging: false,
+      }).setView(latlng, Number(zoom))
 
-        // Habilitar interactividad al hacer clic
-        map.once("click", () => {
-          map.scrollWheelZoom.enable();
-          map.dragging.enable();
-        });
+      // Habilitar interactividad al hacer clic
+      map.once("click", () => {
+        map.scrollWheelZoom.enable()
+        map.dragging.enable()
+      })
 
-        window.L.tileLayer(tiles, { attribution }).addTo(map);
+      L.tileLayer(tiles, { attribution }).addTo(map)
 
-        // Definir icono personalizado
-        const myIcon = window.L.icon({
-          iconUrl: "images/icons/marker.png",
-          iconSize: [25, 41],
-          iconAnchor: [12, 41],
-          popupAnchor: [1, -34],
-          shadowSize: [41, 41],
-        });
+      // Definir icono personalizado
+      const myIcon = L.icon({
+        iconUrl: "images/icons/marker.png",
+        iconSize: [25, 41],
+        iconAnchor: [12, 41],
+        popupAnchor: [1, -34],
+        shadowSize: [41, 41],
+      })
 
-        window.L.marker(latlng, { icon: myIcon })
-          .addTo(map)
-          .bindPopup("Aquopolis Villanueva de la Cañada");
-      }
+      L.marker(latlng, { icon: myIcon }).addTo(map).bindPopup("Aquopolis Villanueva de la Cañada")
     }
-    window.customElements.define("leaflet-map", LeafletMap);
   }
+
+  window.customElements.define("leaflet-map", LeafletMap)
 </script>

--- a/src/sections/Map.astro
+++ b/src/sections/Map.astro
@@ -2,13 +2,12 @@
 import LeafletMap from "@/components/LeafletMap.astro"
 ---
 
-<section id="mapa">
-  <LeafletMap 
-    latitude={40.45673263671421} 
-    longitude={-3.990346247363024} 
-    zoom={15} 
-    container="map-container" 
+<section id="mapa" class="h-[61.8vh]">
+  <LeafletMap
+    latitude={40.45673263671421}
+    longitude={-3.990346247363024}
+    zoom={15}
     tileLayer="https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png"
-    attribution="&copy; OpenStreetMap &copy; CARTO"
+    attribution="© OpenStreetMap © CARTO"
   />
 </section>


### PR DESCRIPTION
- remove `container` (id) prop. `L.map` is overloaded: `L.map` also accepts an HTMLElement, use `this` instead.
- remove `containerstyle` prop to set the size of the map.  Use tailwindcss classes instead in the parent element.
- remove `div` children use `this` instead.
- no need to verify if leaflet-map component is defined (`CyclomaticComplexity--;`).
- remove `window.L` and use `L` from import directly.