### PR TITLE
refactor: refactoring secondary bento cards

### DIFF
--- a/src/components/BentoComponent.astro
+++ b/src/components/BentoComponent.astro
@@ -1,0 +1,36 @@
+---
+interface Props {
+  title?: string
+  image?: string
+  alt?: string
+  link?: string
+  cn?: 'rightTop' | 'rightBottom' | 'bottomLeft' | 'bottomRight'
+}
+
+const gridpos = { 
+  rightTop: 'md:row-span-2 md:col-start-5 flex flex-col p-4',
+  rightBottom: 'md:row-span-2 md:col-start-5 row-start-3 flex flex-col p-4',
+  bottomLeft: 'md:col-span-2 md:row-start-4 relative overflow-hidden',
+  bottomRight: 'md:col-span-2 md:col-start-3 row-start-4 flex flex-col p-4',
+}
+
+const { title, image, alt, link, cn } = Astro.props
+
+const classes = `${cn ? gridpos[cn] : ''} w-full h-full justify-center items-center bg-primary rounded-2xl text-2xl md:text-3xl lg:text-4xl text-white font-black text-center`;
+---
+
+<div class={classes}>
+  {title && (
+    <h2 class="md:-rotate-3">{title}</h2>
+  )}
+  {image && (
+    <a href={link} class="h-full w-full">
+      <img
+        class="absolute -top-15 aspect-video w-auto h-auto object-cover"
+        src={image}
+        alt={alt}
+      />
+    </a>
+  )}
+</div>
+

--- a/src/sections/Hero.astro
+++ b/src/sections/Hero.astro
@@ -1,8 +1,12 @@
+---
+import BentoComponent from "@/components/BentoComponent.astro"
+---
+
 <section class="bg-primary-light pt-16 pb-24">
   <div
-    class="grid grid-cols-1 md:grid-cols-5 md:grid-rows-4 gap-4 max-w-5xl mx-auto"
+    class="grid grid-cols-1 px-4 lg:px-2 md:grid-cols-5 md:grid-rows-4 gap-4 max-w-5xl mx-auto"
   >
-    <div class="md:col-span-4 md:row-span-3 aspect-video rounded-2xl relative hover:scale-101 transition">
+    <div class="md:col-span-4 md:row-span-3 aspect-video rounded-2xl relative">
       <img
         class="rounded-2xl z-10 relative"
         src="/images/lolalolitaland-hero.webp"
@@ -14,33 +18,9 @@
         alt="Fotografía de una joven recostada, que es Lola Lolita, sobre la arena con una cola de sirena azul, frente a una piscina con toboganes rosas en un entorno tropical, con el texto ‘Lola Lolita Land’ en la parte superior."
       />
     </div>
-    <div
-      class="md:row-span-2 md:col-start-5 bg-primary rounded-2xl text-4xl text-center text-white font-black justify-center items-center flex hover:scale-101 transition"
-    >
-      <div class="-rotate-3 flex flex-col">
-        <span>14 & 15</span><span>de junio</span>
-      </div>
-    </div>
-    <div
-      class="md:row-span-2 md:col-start-5 row-start-3 bg-primary rounded-2xl text-4xl text-center text-white font-black justify-center items-center flex hover:scale-101 transition"
-    >
-      <span class="-rotate-3 flex flex-col"> Compra tus entradas </span>
-    </div>
-    <div
-      class="md:col-span-2 md:row-start-4 bg-primary rounded-2xl relative overflow-hidden hover:scale-101 transition"
-    >
-      <a href="/#mapa">
-        <img
-          class="absolute -top-20"
-          src="/images/map.webp"
-          alt="Mapa de la ubicación del evento de Lola Lolita Land"
-        />
-      </a>
-    </div>
-    <div
-      class="md:col-span-2 md:col-start-3 row-start-4 bg-primary rounded-2xl hover:scale-101 transition"
-    >
-      5
-    </div>
+    <BentoComponent title="14 & 15 de junio" cn="rightTop" />
+    <BentoComponent title="Compra tus entradas" cn="rightBottom" />
+    <BentoComponent cn="bottomLeft" link="/#mapa" image="/images/map.webp" alt="Mapa de la ubicación del evento de Lola Lolita Land" />
+    <BentoComponent title="5" cn="bottomRight" />
   </div>
 </section>

--- a/src/sections/Tickets.astro
+++ b/src/sections/Tickets.astro
@@ -1,19 +1,19 @@
 ---
-import Marquee from '@/components/Marquee.astro'
+import Marquee from "@/components/Marquee.astro"
 ---
 
-<div class="w-full overflow-hidden relative">
-  <div class="w-[110%] -rotate-3 bg-theme-green-light text-white -ml-2 my-[3%] mx-auto">
+<div class="w-full overflow-hidden relative select-none">
+  <div class="w-[110%] -rotate-3 bg-theme-green-light text-white -ml-2 mt-[3%] mx-auto">
     <Marquee
       content={[
-        'Entradas',
-        'Entradas',
-        'Entradas',
-        'Entradas',
-        'Entradas',
-        'Entradas',
-        'Entradas',
-        'Entradas',
+        "Entradas",
+        "Entradas",
+        "Entradas",
+        "Entradas",
+        "Entradas",
+        "Entradas",
+        "Entradas",
+        "Entradas",
       ]}
     />
   </div>


### PR DESCRIPTION
BentoComponent, created to refactor and simplify the Hero section. Previously, the Hero section consisted of four separate grid sections.

````
const gridpos = { 
  rightTop: 'md:row-span-2 md:col-start-5 flex flex-col p-4',
  rightBottom: 'md:row-span-2 md:col-start-5 row-start-3 flex flex-col p-4',
  bottomLeft: 'md:col-span-2 md:row-start-4 relative overflow-hidden',
  bottomRight: 'md:col-span-2 md:col-start-3 row-start-4 flex flex-col p-4',
}
````

Some adjustments with the padding for small devices responsiveness

![image](https://github.com/user-attachments/assets/caec3d69-56d7-4c4b-ae54-15d158be1c1c)

Additionally, a small fix was made in the Tickets section, where the selection functionality has been disabled.