### PR TITLE
feat: tile color change without changing the tile server

### DIFF
--- a/src/components/LeafletMap.astro
+++ b/src/components/LeafletMap.astro
@@ -61,3 +61,9 @@ const { latitude, longitude, zoom, container, tileLayer, attribution } = Astro.p
 
   window.customElements.define("leaflet-map", LeafletMap)
 </script>
+
+<style is:global>
+  .leaflet-tile {
+    filter: hue-rotate(220deg);
+  }
+</style>


### PR DESCRIPTION
> [!IMPORTANT]
> in order to have a custom tile color we need a tile server that allows change tile colors on demand: google maps, mapbox, etc. have but the usage of them api costs money.  Openstreetmaps doesn't have this feature.  

We have some options:

- Use another public free tile provider.  There is a preview demo in github: https://leaflet-extras.github.io/leaflet-providers/preview/ (i did not found a pinkish tile server...)
- <strike>Create a custom provider tile server...</strike> https://openmaptiles.org/
- 🦄 **_Hack the color a little bit via css_** 🦄

## Hack the color a little bit via css

This approach can solve with limitations by aplying a color filter via css.

Before:

![imagen](https://github.com/user-attachments/assets/9de23d61-8705-493f-8381-f285dcc4b3d9)

After:

![imagen](https://github.com/user-attachments/assets/07f9044a-f1d0-48b2-bad8-024118c87b0f)


