### PR TITLE
fix: assigning text-stroke correctly and padding for responsive sections hero

### DIFF
--- a/src/sections/Hero.astro
+++ b/src/sections/Hero.astro
@@ -15,9 +15,9 @@
       />
     </div>
     <div
-      class="md:row-span-2 md:col-start-5 bg-primary-light rounded-2xl text-4xl text-center text-stroke text-primary font-black justify-center items-center flex hover:scale-101 transition"
+      class="md:row-span-2 md:col-start-5 bg-primary-light rounded-2xl md:text-4xl text-3xl p-2 text-center text-primary font-black justify-center items-center flex hover:scale-101 transition"
     >
-      <div class="-rotate-3 flex flex-col">
+      <div class="-rotate-3 flex flex-col text-stroke">
         <span class="text-6xl">14</span>
         <span>&</span>
         <span class="text-6xl">15</span>
@@ -25,14 +25,14 @@
       </div>
     </div>
     <div
-      class="md:row-span-2 md:col-start-5 row-start-3 bg-primary-light text-stroke text-primary rounded-2xl text-4xl text-center font-black justify-center items-center flex hover:scale-101 transition"
+      class="md:row-span-2 md:col-start-5 row-start-3 bg-primary-light md:py-0 py-3 text-primary rounded-2xl text-4xl text-center font-black justify-center items-center flex hover:scale-101 transition"
     >
-      <a href="/#tickets" class="flex h-full items-center justify-center">
-        <span class="-rotate-3"> Compra tus entradas </span>
+      <a href="/#tickets" class="flex h-full items-center justify-center text-stroke">
+        <span class="-rotate-2">Compra tus entradas</span>
       </a>
     </div>
     <div
-      class="md:col-span-2 md:row-start-4 bg-primary rounded-2xl relative overflow-hidden"
+      class="md:col-span-2 md:row-start-4 bg-primary-light rounded-2xl relative overflow-hidden md:py-0 py-3"
     >
       <a href="/#mapa" class="flex w-full h-full items-center justify-center gap-4">
         <!-- <img
@@ -41,16 +41,15 @@
           alt="Mapa de la ubicación del evento de Lola Lolita Land"
         /> -->
         <img src="/icons/marker.svg" alt="" class="w-16 -rotate-3">
-        <p class="flex flex-col">
-          <span class="-rotate-3">Aquopolis,</span>
+        <p class="flex flex-col text-primary font-black text-4xl text-stroke">
+          <span class="-rotate-3">Aquopolis</span>
           <span class="-rotate-3">Madrid</span>
         </p>
       </a>
     </div>
     <div
-      class="md:col-span-2 md:col-start-3 row-start-4 bg-primary rounded-2xl"
+      class="md:col-span-2 md:row-start-4 bg-primary-light rounded-2xl relative overflow-hidden md:py-0 py-3"
     >
-      5
     </div>
   </div>
 </section>


### PR DESCRIPTION
En las secciones que se agregaron el mapa y los tickets les puse el fondo primario, que cogiera bien el stroke al texto de "Compra tus tickets", con la idea de que se vea mejor estéticamente  y mejore el responsivo. 
![image](https://github.com/user-attachments/assets/83a22650-1e80-4bb4-91ed-ae4d1d1834b3)
![image](https://github.com/user-attachments/assets/f81598bd-8f6e-4b61-bdae-6f0eaffb0c7c)
