### PR TITLE
Fix: Correctly display complete calendar image on mobile devices

### DIFF
--- a/src/sections/Hero.astro
+++ b/src/sections/Hero.astro
@@ -43,7 +43,7 @@ import DotBackground from "../components/DotBackground.astro"
         >
           <div class="relative h-80 w-full overflow-hidden">
             <img
-              class="relative h-full w-full object-cover object-center [mask-image:linear-gradient(to_bottom,black_80%,transparent_100%)]"
+              class="relative h-full w-full object-fill sm:object-cover object-center [mask-image:linear-gradient(to_bottom,black_80%,transparent_100%)]"
               src="/images/calendario.webp"
               alt=""
             />


### PR DESCRIPTION
La fecha del 15 se está cortando en la imagen del calendario al verlo desde un dispositvo móvil:

![Current calendar image cutting off](https://github.com/user-attachments/assets/7d4ba0b6-22e1-48e2-a0b3-b61eb289a4ec)

Se agregó un cambio para mostrarla completa en móviles:
![Change applied to display calendar image completely](https://github.com/user-attachments/assets/2a964755-db1a-4d76-a506-7677eba41764)
