### PR TITLE
feature: Add translate animation from left edge to menu when opening and closing

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -64,9 +64,8 @@
       </div>
     </div>
   </nav>
-  <div class="relative z-50 hidden lg:hidden" id="mobile-menu" role="dialog" aria-modal="true">
-    <div class="fixed inset-0 z-10"></div>
-    <div class="fixed inset-y-0 left-0 z-10 w-full overflow-y-auto bg-white px-6 py-6">
+  <div class="fixed top-0 z-50 w-full hidden lg:hidden [&.hidden]:translate-x-[-100%] starting:translate-x-[-100%] transition-translate-[0%] transition-(display) duration-[.3s] transition-discrete" id="mobile-menu" role="dialog" aria-modal="true">
+    <div class="z-10 max-h-screen h-screen w-full overflow-y-auto bg-white px-6 py-6">
       <div class="flex items-center justify-between">
         <div class="flex flex-1">
           <button


### PR DESCRIPTION
El menú  en dispositivos móviles no tienen ninguna animación o transición:
![Menu without animation](https://github.com/user-attachments/assets/49a85079-13ad-4504-913d-558a07ebd951)

Se agregó una transición `translate` desde el borde izquierdo al abrir y cerrar el menú:
![Menu_animation](https://github.com/user-attachments/assets/d9e368f8-c293-4a5d-94b3-4e705996ccd2)
