### PR TITLE
Feat: add hove on open and close menu and move info id into bento grid 

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -25,7 +25,7 @@
         <button
           type="button"
           id="open-menu-button"
-          class="-m-2.5 inline-flex cursor-pointer items-center justify-center rounded-md p-2.5 text-gray-700"
+          class="hover:text-primary -m-2.5 inline-flex cursor-pointer items-center justify-center rounded-md p-2.5 text-gray-700 transition-all duration-300 will-change-transform hover:scale-125"
         >
           <span class="sr-only">Abrir Menú Principal</span>
           <svg
@@ -77,7 +77,7 @@
           <button
             type="button"
             id="close-menu-button"
-            class="-m-2.5 rounded-md p-2.5 text-gray-700"
+            class="hover:text-primary -m-2.5 cursor-pointer rounded-md p-2.5 text-gray-700 transition-all duration-300 ease-in will-change-transform hover:scale-125"
           >
             <span class="sr-only">Cerrar Menú</span>
             <svg

--- a/src/sections/Hero.astro
+++ b/src/sections/Hero.astro
@@ -2,7 +2,7 @@
 import DotBackground from "../components/DotBackground.astro"
 ---
 
-<section id="info" class="relative mx-4 pt-12 pb-24">
+<section class="relative mx-4 pt-12 pb-24">
   <DotBackground />
   <div class="relative mx-auto mb-16 max-w-6xl">
     <img
@@ -32,7 +32,7 @@ import DotBackground from "../components/DotBackground.astro"
         >¿Estáis preparados para<br />pasar dos días inolvidables?</span
       >
     </div>
-    <div class="mt-10 grid grid-cols-1 gap-4 sm:mt-16 lg:grid-cols-6 lg:grid-rows-2">
+    <div class="grid grid-cols-1 gap-4 pt-10 sm:mt-16 lg:grid-cols-6 lg:grid-rows-2" id="info">
       <div class="relative lg:col-span-3">
         <div
           class="absolute inset-px rounded-lg bg-white max-lg:rounded-t-[2rem] lg:rounded-tl-[2rem]"


### PR DESCRIPTION
## ¿Qué se ha hecho en esta PR?

Se ha añadido animaciones al hacer hover sobre los botones de abrir y cerrar menú, también se ha movido el ID del section ifo dentro del bento grid.



---

## Tipo de cambio

Marca las opciones relevantes para esta PR:

- [x] Corrección de errores (cambio no disruptivo que soluciona un problema)
- [ ] Nueva funcionalidad (cambio no disruptivo que añade una nueva funcionalidad)
- [ ] Cambio disruptivo (corrección o funcionalidad que causa que una funcionalidad existente no funcione como se espera)
- [ ] Mejora de documentación

---

## ¿Se han realizado tests automáticos?

- [ ] Sí
- [x] No

---

## ¿Cuál es el comportamiento esperado tras el cambio?
No afecta al comportamiento del producto final.

---

## ¿Cómo se pueden testear las características introducidas en esta PR?


Haciendo hover sobre los botones de abrir y cerrar menú y dándole click a INFO.

---

## Capturas de pantalla


![chrome-capture-2025-3-11](https://github.com/user-attachments/assets/bbcc030e-3f77-4816-ad63-7e728743639c)

---
