### PR TITLE
feature: Position calendar image inclined to the right on mobile devices and center on larger devices

### DIFF
--- a/src/sections/Hero.astro
+++ b/src/sections/Hero.astro
@@ -49,7 +49,7 @@ import DotBackground from "../components/DotBackground.astro"
         >
           <div class="relative h-80 w-full overflow-hidden">
             <img
-              class="relative h-full w-full object-cover object-center object-right [mask-image:linear-gradient(to_bottom,black_80%,transparent_100%)]"
+              class="relative h-full w-full object-cover object-[85%_center] sm:object-center [mask-image:linear-gradient(to_bottom,black_80%,transparent_100%)]"
               src="/images/calendario.webp"
               alt=""
             />


### PR DESCRIPTION
## ¿Qué se ha hecho en esta PR?

Se posicionó la imagen del calendario a la derecha en dispositivos móviles y centrada en dispositivos más grandes.

---

## Tipo de cambio

Marca las opciones relevantes para esta PR:

- [x] Corrección de errores (cambio no disruptivo que soluciona un problema)
- [ ] Nueva funcionalidad (cambio no disruptivo que añade una nueva funcionalidad)
- [ ] Cambio disruptivo (corrección o funcionalidad que causa que una funcionalidad existente no funcione como se espera)
- [ ] Mejora de documentación

---

## ¿Se han realizado tests automáticos?

- [ ] Sí
- [x] No

---

## ¿Cuál es el comportamiento esperado tras el cambio?

Mejor visualización de la imagen del calendario en dispositivos móviles sin afectar a dispositivos más grandes.

---

## ¿Cómo se pueden testear las características introducidas en esta PR?

Visualizar la imagen del calendario en un dispositivo móvil.

---

## Capturas de pantalla
Actualmente la posición a la derecha de la imagen, aparenta tener un espacio vacío a la derecha del card.
![Imagen completamente posicionada a la derecha](https://github.com/user-attachments/assets/e0a9d1c9-24a7-4d2a-b2b1-328169e45ed2)

Posicionando la imagen 85% sobre el eje x hace que el espacio en blanco a la derecha se disminuya:
![Imagen inclinada a la derecha](https://github.com/user-attachments/assets/3fa5d881-8ff6-44c8-a053-a61cba5d8328)


---

## Enlaces adicionales

No hay enlaces adicionales.