### PR TITLE
Feature/made menu to stick when scrolling down

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,4 +1,4 @@
-<header class="relative">
+<header class="sticky top-0 z-60 animate-blur-header">
   <nav
     class="mx-auto flex max-w-6xl items-center justify-between px-4 py-6 pb-0 uppercase lg:px-8"
     aria-label="Global"
@@ -64,14 +64,13 @@
       </div>
     </div>
   </nav>
-  <div
-    class="fixed inset-0 z-[9999] h-full w-full -translate-x-full transform transition duration-300 lg:hidden"
+  <dialog
+    class="z-50 max-h-full max-w-full size-full lg:hidden starting:-translate-x-full transition-(display) translate-x-0 duration-300 transition-discrete [&:not([open])]:-translate-x-full"
     id="mobile-menu"
     role="dialog"
     aria-modal="true"
   >
-    <div class="fixed inset-0 z-10"></div>
-    <div class="fixed inset-y-0 left-0 z-10 w-full overflow-y-auto bg-white px-6 py-6">
+    <div class="z-10 overflow-y-auto bg-white px-6 py-6">
       <div class="flex items-center justify-between">
         <div class="flex flex-1">
           <button
@@ -117,7 +116,7 @@
         >
       </div>
     </div>
-  </div>
+  </dialog>
 </header>
 
 <script>
@@ -128,7 +127,9 @@
   const mobileItems = mobileMenu?.querySelectorAll("a")
 
   const toggleMenu = () => {
-    mobileMenu?.classList.toggle("-translate-x-full")
+    mobileMenu.open
+      ? mobileMenu.close()
+      : mobileMenu.showModal()
   }
 
   // Add event listener to open menu button
@@ -139,3 +140,24 @@
 
   mobileItems?.forEach((item) => item.addEventListener("click", toggleMenu))
 </script>
+
+<style>
+  header {
+    animation: blur-header .3s linear both;
+    animation-timeline: scroll();
+    animation-range: 0 150px;
+  }
+
+  @keyframes blur-header {
+    0% {
+      backdrop-filter: blur(0);
+      background-color: transparent;
+    }
+
+    100% {
+      backdrop-filter: blur(10px);
+      background-color: rgba(255, 255, 255, 0.8);
+      padding-bottom: calc(var(--spacing)* 6);/* pb-6 */
+    }
+  }
+</style>

--- a/src/components/LeafletMap.astro
+++ b/src/components/LeafletMap.astro
@@ -87,4 +87,8 @@ const { latitude, longitude, zoom, tileLayer, attribution, geoJSON } = Astro.pro
   .leaflet-tile {
     filter: hue-rotate(220deg);
   }
+
+  .leaflet-pane {
+    z-index: 10;
+  }
 </style>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -19,7 +19,7 @@ const {
 ---
 
 <!doctype html>
-<html lang="es">
+<html lang="es" class="scroll-smooth">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width" />
@@ -27,7 +27,7 @@ const {
     <title>{title}</title>
   </head>
 
-  <body class="w-screen overflow-x-hidden scroll-smooth">
+  <body class="w-screen overflow-x-hidden">
     <Header />
     <slot />
   </body>


### PR DESCRIPTION
## ¿Qué se ha hecho en esta PR?
Se modificó la barra de menú para que se matenga en el top de la página al hacer scroll.
* Se movió la clase scroll-smoth a la etiqueta html para un desplazamiento suave en toda la página.
* Se redujo el z-index leaflet map para que se muestre debajo de la barra de menú.
* Se cambió la etiqueta html utilizada para crear el menú emergente por un dialog, lo que permite abrir el menú incluso al desplazarse hacia abajo.

---

## Tipo de cambio

Marca las opciones relevantes para esta PR:

- [x] Corrección de errores (cambio no disruptivo que soluciona un problema)
- [x] Nueva funcionalidad (cambio no disruptivo que añade una nueva funcionalidad)
- [ ] Cambio disruptivo (corrección o funcionalidad que causa que una funcionalidad existente no funcione como se espera)
- [ ] Mejora de documentación

---

## ¿Se han realizado tests automáticos?

- [ ] Sí
- [x] No

---

## ¿Cuál es el comportamiento esperado tras el cambio?

El menú se debe de mantener en su posición al hacer scroll por la página.
En dispositivos móviles, el menú debe de poderse abrir sin importar a que altura de la página se encuentre.

---

## ¿Cómo se pueden testear las características introducidas en esta PR?

Realizar scroll en dispositivos móviles o desktop para ver que como el menú se mantiene en su posición y se puede navergar a través de él.

---

## Capturas de pantalla

https://github.com/user-attachments/assets/2f21e9b4-a36b-467e-8f3d-ecfa458a892b




---

## Enlaces adicionales

No hay enlaces adicionales.