### PR TITLE
Refactor: Refactorización del componente Hero: eliminación de divs absolutos

### DIFF
--- a/src/sections/Hero.astro
+++ b/src/sections/Hero.astro
@@ -43,11 +43,7 @@ import CalendarImage from "@/assets/images/calendario.webp"
     >
       <div class="relative lg:col-span-3">
         <div
-          class="absolute inset-px rounded-lg bg-white max-lg:rounded-t-[2rem] lg:rounded-tl-[2rem]"
-        >
-        </div>
-        <div
-          class="relative flex h-full flex-col overflow-hidden rounded-[calc(var(--radius-lg)+1px)] max-lg:rounded-t-[calc(2rem+1px)] lg:rounded-tl-[calc(2rem+1px)]"
+          class="relative flex h-full flex-col overflow-hidden rounded-[calc(var(--radius-lg)+1px)] bg-white max-lg:rounded-t-[calc(2rem+1px)] lg:rounded-tl-[calc(2rem+1px)]"
         >
           <div class="relative h-80 w-full overflow-hidden">
             <Image
@@ -75,9 +71,8 @@ import CalendarImage from "@/assets/images/calendario.webp"
         </div>
       </div>
       <div class="relative lg:col-span-3">
-        <div class="absolute inset-px rounded-lg bg-white lg:rounded-tr-[2rem]"></div>
         <div
-          class="relative flex h-full flex-col overflow-hidden rounded-[calc(var(--radius-lg)+1px)] lg:rounded-tr-[calc(2rem+1px)]"
+          class="relative flex h-full flex-col overflow-hidden rounded-[calc(var(--radius-lg)+1px)] bg-white lg:rounded-tr-[calc(2rem+1px)]"
         >
           <div class="relative h-80 w-full overflow-hidden">
             <img
@@ -103,9 +98,8 @@ import CalendarImage from "@/assets/images/calendario.webp"
         </div>
       </div>
       <div class="relative lg:col-span-2">
-        <div class="absolute inset-px rounded-lg bg-white lg:rounded-bl-[2rem]"></div>
         <div
-          class="relative flex h-full flex-col overflow-hidden rounded-[calc(var(--radius-lg)+1px)] lg:rounded-bl-[calc(2rem+1px)]"
+          class="relative flex h-full flex-col overflow-hidden rounded-[calc(var(--radius-lg)+1px)] bg-white lg:rounded-bl-[calc(2rem+1px)]"
         >
           <div class="relative h-80 w-full overflow-hidden">
             <img
@@ -130,9 +124,8 @@ import CalendarImage from "@/assets/images/calendario.webp"
         </div>
       </div>
       <div class="relative lg:col-span-2">
-        <div class="absolute inset-px rounded-lg bg-white"></div>
         <div
-          class="relative flex h-full flex-col overflow-hidden rounded-[calc(var(--radius-lg)+1px)]"
+          class="relative flex h-full flex-col overflow-hidden rounded-[calc(var(--radius-lg)+1px)] bg-white"
         >
           <div class="relative h-80 w-full overflow-hidden">
             <img
@@ -156,11 +149,7 @@ import CalendarImage from "@/assets/images/calendario.webp"
       </div>
       <div class="relative lg:col-span-2">
         <div
-          class="absolute inset-px rounded-lg bg-white max-lg:rounded-b-[2rem] lg:rounded-br-[2rem]"
-        >
-        </div>
-        <div
-          class="relative flex h-full flex-col overflow-hidden rounded-[calc(var(--radius-lg)+1px)] max-lg:rounded-b-[calc(2rem+1px)] lg:rounded-br-[calc(2rem+1px)]"
+          class="relative flex h-full flex-col overflow-hidden rounded-[calc(var(--radius-lg)+1px)] bg-white max-lg:rounded-b-[calc(2rem+1px)] lg:rounded-br-[calc(2rem+1px)]"
         >
           <div class="relative h-80 w-full overflow-hidden">
             <img


### PR DESCRIPTION
### Descripción de los cambios
Se ha eliminado el `div` que actuaba como fondo (`<div class="absolute inset-px rounded-lg bg-white lg:rounded-tr-[2rem]"></div>`) y se ha trasladado la propiedad `bg-white` al `div` hermano siguiente. Este cambio simplifica la estructura del código y mantiene el mismo estilo visual, optimizando el uso de clases y evitando elementos innecesarios.

### Motivación
El `div` eliminado no parecía tener una funcionalidad adicional más allá de actuar como fondo, por lo que su eliminación no afecta al comportamiento del componente. Al mover la propiedad `bg-white` al `div` contenedor, se reduce la complejidad del código y se mejora su mantenibilidad.

### Impacto
- **Visual:** No hay cambios visuales, ya que el fondo blanco y los bordes redondeados se mantienen.
- **Funcional:** No se esperan impactos en la funcionalidad del componente.
- **Código:** La estructura del HTML es más limpia y sencilla.

### Pruebas realizadas
- Se ha verificado que el componente se renderiza correctamente en diferentes tamaños de pantalla.
- Se ha comprobado que los estilos (fondo blanco y bordes redondeados) se aplican correctamente.

### Notas adicionales
Si este `div` eliminado tenía alguna funcionalidad no documentada o específica, por favor, házmelo saber para revisar el cambio en detalle.