### PR TITLE
Fix/lightbox close button

### DIFF
--- a/src/sections/Gallery.astro
+++ b/src/sections/Gallery.astro
@@ -25,7 +25,7 @@ import { Image } from "astro:assets"
               width={950}
               height={900}
               class="border-theme-blue-light h-full w-full rounded-md border border-dashed object-cover"
-              transition:name="ligtbox-1"
+              transition:name="lightbox-1"
               loading="lazy"
             />
           </li>
@@ -64,7 +64,7 @@ import { Image } from "astro:assets"
         class="h-full w-full rounded-md"
         width={2000}
         height={1300}
-        transition:name="ligtbox-1"
+        transition:name="lightbox-1"
       />
     </div>
   </div>
@@ -87,8 +87,10 @@ import { Image } from "astro:assets"
 
   galleryItems.forEach((eachItem) => {
     eachItem.addEventListener("click", () => {
+      if (lightBoxImg) {
+        lightBoxImg.src = eachItem.src
+      }
       openLightBox()
-      lightBoxImg.src = eachItem.src
     })
   })
 
@@ -99,7 +101,7 @@ import { Image } from "astro:assets"
   lightBoxImg.addEventListener("click", (event) => {
     event.stopPropagation()
   })
-  btnCloseLightBox.addEventListener("click", (eent) => {
+  btnCloseLightBox.addEventListener("click", (event) => {
     closeLightBox()
   })
 </script>

--- a/src/sections/Gallery.astro
+++ b/src/sections/Gallery.astro
@@ -104,4 +104,9 @@ import { Image } from "astro:assets"
   btnCloseLightBox.addEventListener("click", (event) => {
     closeLightBox()
   })
+  document.addEventListener("keydown", (event) => {
+    if (event.key === "Escape") {
+      closeLightBox()
+    }
+  })
 </script>

--- a/src/sections/Gallery.astro
+++ b/src/sections/Gallery.astro
@@ -43,7 +43,7 @@ import { Image } from "astro:assets"
       <button
         type="button"
         id="close-lightbox"
-        class="hover:text-primary absolute -top-8 -right-1 -m-2.5 cursor-pointer rounded-full bg-white p-2.5 text-gray-700 transition-all duration-300 ease-in will-change-transform hover:scale-125"
+        class="hover:text-primary absolute top-4 right-4 z-[10000] -m-2.5 cursor-pointer rounded-full bg-white p-2.5 text-gray-700 transition-all duration-300 ease-in will-change-transform hover:scale-125 sm:top-6 sm:right-6 md:top-8 md:right-8 lg:top-10 lg:right-1"
       >
         <span class="sr-only">Cerrar Galería</span>
         <svg
@@ -58,10 +58,11 @@ import { Image } from "astro:assets"
           <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"></path>
         </svg>
       </button>
+
       <Image
         src={GalleryImg1}
         alt="Gallery Image 1"
-        class="h-full w-full rounded-md"
+        class="h-full w-max rounded-md"
         width={2000}
         height={1300}
         transition:name="lightbox-1"


### PR DESCRIPTION
## **¿Qué se ha hecho en esta PR?**  

Se ha mejorado el posicionamiento del botón de cerrar en el **Lightbox**, ajustando su posición dinámicamente según el tamaño de la pantalla.  
Ahora, el botón mantiene una alineación adecuada en distintos **breakpoints** (`sm`, `md`, `lg`), mejorando la accesibilidad y visibilidad en dispositivos móviles y de escritorio.  

📌 **Cambios principales:**  
- Se ajustó `top` y `right` utilizando clases de **Tailwind CSS** para distintos tamaños de pantalla.  
- Se optimizó la visibilidad del botón en resoluciones pequeñas sin afectar la experiencia en escritorio.  

**Arregla:** No hay un issue asociado.  

---

## **Tipo de cambio**  

Marca las opciones relevantes para esta PR:  

- [x]  **Corrección de errores** (cambio no disruptivo que soluciona un problema)  
- [ ]  **Nueva funcionalidad** (cambio no disruptivo que añade una nueva funcionalidad)  
- [ ]  **Cambio disruptivo** (corrección o funcionalidad que causa que una existente no funcione como se espera)  
- [ ]  **Mejora de documentación**  

---

## **¿Se han realizado tests automáticos?**  

- [ ] Sí  
- [x] No 

---

## **¿Cuál es el comportamiento esperado tras el cambio?**  

- El botón de **cerrar (`X`)** en el Lightbox se posiciona correctamente en todos los tamaños de pantalla.  
- La experiencia de usuario mejora en dispositivos móviles, evitando que el botón se solape o quede fuera de la vista.  

---

## **¿Cómo se pueden testear las características introducidas en esta PR?**  

1. Abrir la galería y hacer clic en una imagen para activar el **Lightbox**.  
2. Verificar que el botón de cerrar (`X`) se mantenga bien posicionado en **distintos tamaños de pantalla** (`sm`, `md`, `lg`).  
3. Probar en dispositivos móviles y de escritorio para confirmar que el cambio funciona correctamente.  

---

## **Capturas de pantalla**  

### **Antes del cambio:**  
El botón de cerrar (`X`) se posicionaba incorrectamente en ciertos tamaños de pantalla.  

![Antes del cambio](https://github.com/user-attachments/assets/010e0857-73b8-4a0a-9f2c-cf8d15f3333b)

### **Después del cambio:**  
Ahora, el botón se ajusta dinámicamente según el tamaño de pantalla.  
 
![Después del cambio](https://github.com/user-attachments/assets/e265dc1b-a5d5-4bb5-8987-367c90cea9ef)


---

## **Enlaces adicionales**  

No hay enlaces adicionales.  

---

