### PR TITLE
Feat: header update

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -16,6 +16,11 @@
           >Preguntas</a
         >
         <a
+          href="/#gallery"
+          class="relative text-sm/6 font-semibold text-white after:absolute after:bottom-[-2px] after:left-0 after:h-0.5 after:w-0 after:bg-[#61E2E5] after:transition-all after:duration-300 hover:text-[#61E2E5] hover:after:w-full"
+          >Galeria 2024</a
+        >
+        <a
           href="/hoja-de-responsabilidad.pdf"
           class="relative text-sm/6 font-semibold text-white after:absolute after:bottom-[-2px] after:left-0 after:h-0.5 after:w-0 after:bg-[#61E2E5] after:transition-all after:duration-300 hover:text-[#61E2E5] hover:after:w-full"
           >Aut. Menores</a
@@ -99,6 +104,11 @@
           >Preguntas</a
         >
         <a
+          href="/#gallery"
+          class="-mx-3 block rounded-lg px-3 py-2 text-base/7 font-semibold text-white hover:bg-[#FF0695]/10 hover:text-[#FF0695]"
+          >Galeria 2024</a
+        >
+        <a
           href="/hoja-de-responsabilidad.pdf"
           class="-mx-3 block rounded-lg px-3 py-2 text-base/7 font-semibold text-white hover:bg-[#FF0695]/10 hover:text-[#FF0695]"
           >Aut. Menores</a
@@ -115,7 +125,7 @@
 
 <script>
   // Get the menu elements
-  const mobileMenu = document.getElementById("mobile-menu")
+  const mobileMenu = document.getElementById("mobile-menu") as HTMLDialogElement
   const openMenuButton = document.getElementById("open-menu-button")
   const closeMenuButton = document.getElementById("close-menu-button")
   const mobileItems = mobileMenu?.querySelectorAll("a")

--- a/src/sections/Gallery.astro
+++ b/src/sections/Gallery.astro
@@ -25,7 +25,7 @@ import { Image } from "astro:assets"
               width={950}
               height={900}
               class="border-theme-blue-light h-full w-full rounded-md border border-dashed object-cover"
-              transition:name="ligtbox-1"
+              transition:name="lightbox-1"
               loading="lazy"
             />
           </li>
@@ -64,7 +64,7 @@ import { Image } from "astro:assets"
         class="h-full w-full rounded-md"
         width={2000}
         height={1300}
-        transition:name="ligtbox-1"
+        transition:name="lightbox-1"
       />
     </div>
   </div>
@@ -87,8 +87,10 @@ import { Image } from "astro:assets"
 
   galleryItems.forEach((eachItem) => {
     eachItem.addEventListener("click", () => {
+      if (lightBoxImg) {
+        lightBoxImg.src = eachItem.src
+      }
       openLightBox()
-      lightBoxImg.src = eachItem.src
     })
   })
 
@@ -99,7 +101,7 @@ import { Image } from "astro:assets"
   lightBoxImg.addEventListener("click", (event) => {
     event.stopPropagation()
   })
-  btnCloseLightBox.addEventListener("click", (eent) => {
+  btnCloseLightBox.addEventListener("click", (event) => {
     closeLightBox()
   })
 </script>

--- a/src/sections/Gallery.astro
+++ b/src/sections/Gallery.astro
@@ -104,4 +104,9 @@ import { Image } from "astro:assets"
   btnCloseLightBox.addEventListener("click", (event) => {
     closeLightBox()
   })
+  document.addEventListener("keydown", (event) => {
+    if (event.key === "Escape") {
+      closeLightBox()
+    }
+  })
 </script>

--- a/src/sections/Gallery.astro
+++ b/src/sections/Gallery.astro
@@ -43,7 +43,7 @@ import { Image } from "astro:assets"
       <button
         type="button"
         id="close-lightbox"
-        class="hover:text-primary absolute -top-8 -right-1 -m-2.5 cursor-pointer rounded-full bg-white p-2.5 text-gray-700 transition-all duration-300 ease-in will-change-transform hover:scale-125"
+        class="hover:text-primary absolute top-4 right-4 z-[10000] -m-2.5 cursor-pointer rounded-full bg-white p-2.5 text-gray-700 transition-all duration-300 ease-in will-change-transform hover:scale-125 sm:top-6 sm:right-6 md:top-8 md:right-8 lg:top-10 lg:right-1"
       >
         <span class="sr-only">Cerrar Galería</span>
         <svg
@@ -58,10 +58,11 @@ import { Image } from "astro:assets"
           <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"></path>
         </svg>
       </button>
+
       <Image
         src={GalleryImg1}
         alt="Gallery Image 1"
-        class="h-full w-full rounded-md"
+        class="h-full w-max rounded-md"
         width={2000}
         height={1300}
         transition:name="lightbox-1"


### PR DESCRIPTION
## ¿Qué se ha hecho en esta PR?

Se ha agregado un nuevo enlace **"Galería 2024"** al header de la página y se ha mejorado la funcionalidad del menú móvil, asegurando un comportamiento más consistente al abrir y cerrar el menú.

### Cambios principales:
- Se añadió el enlace **"Galería 2024"** en el header.
- Se mejoró el código de apertura y cierre del menú móvil para evitar posibles errores con `null`.

**Arregla:** No hay un issue asociado.

---

## Tipo de cambio

Marca las opciones relevantes para esta PR:

- [ ] Corrección de errores (cambio no disruptivo que soluciona un problema)
- [x] Nueva funcionalidad (cambio no disruptivo que añade una nueva funcionalidad)
- [ ] Cambio disruptivo (corrección o funcionalidad que causa que una funcionalidad existente no funcione como se espera)
- [ ] Mejora de documentación

---

## ¿Se han realizado tests automáticos?

- [ ] Sí
- [x] No

---

## ¿Cuál es el comportamiento esperado tras el cambio?

- El enlace **"Galería 2024"** debe aparecer en el header junto a los demás enlaces.

---

## ¿Cómo se pueden testear las características introducidas en esta PR?

1. Verificar que el enlace **"Galería 2024"** esté visible en el header.

---

## Capturas de pantalla

Antes del cambio:
![Antes](https://github.com/user-attachments/assets/5c704b2a-bb84-424e-a7a6-f6e60f658a04)

Después del cambio:
![Despues](https://github.com/user-attachments/assets/3ab2176f-911d-448f-9d7d-80a380defab6)
## Enlaces adicionales

No hay enlaces adicionales.
