### PR TITLE
Fix: Hamburger icon desaparece al hacer hover

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -25,7 +25,7 @@
         <button
           type="button"
           id="open-menu-button"
-          class="hover:text-primary -m-2.5 inline-flex cursor-pointer items-center justify-center rounded-md p-2.5 text-white transition-all duration-300 will-change-transform hover:scale-150"
+          class="-m-2.5 inline-flex cursor-pointer items-center justify-center rounded-md p-2.5 text-white transition-all duration-300 will-change-transform hover:scale-150"
         >
           <span class="sr-only">Abrir Menú Principal</span>
           <svg


### PR DESCRIPTION
## ¿Qué se ha hecho en esta PR?

Se elimina `hover:text:primary` del hamburger icon

---

## Tipo de cambio

Marca las opciones relevantes para esta PR:

- [x] Corrección de errores (cambio no disruptivo que soluciona un problema)
- [ ] Nueva funcionalidad (cambio no disruptivo que añade una nueva funcionalidad)
- [ ] Cambio disruptivo (corrección o funcionalidad que causa que una funcionalidad existente no funcione como se espera)
- [ ] Mejora de documentación

---

## ¿Se han realizado tests automáticos?

- [ ] Sí
- [x] No

---

## ¿Cuál es el comportamiento esperado tras el cambio?

Al hacer hover en el hamburger icon éste no desaparece.