### PR TITLE
feat: add WaveSeparator on Gallery

### DIFF
--- a/src/components/WaveSeparator.astro
+++ b/src/components/WaveSeparator.astro
@@ -1,0 +1,29 @@
+---
+const { bottomColor = "#ff0695" } = Astro.props
+---
+
+<div class="wave-container" style={`--bottom-color: ${bottomColor}; `}></div>
+
+<style>
+  .wave-container {
+    position: relative;
+  }
+
+  .wave-container::before {
+    content: "";
+    width: 100%;
+    height: 15px;
+    position: absolute;
+    bottom: -0.3%;
+    left: 0;
+    background-color: var(--bottom-color);
+    mask-image: url("data:image/svg+xml;utf8,<svg viewBox='0 0 1200  134' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M0 98L50 92C100 86 200 74 300 50C400 26 500 -10 600 2C700 14 800 74 900 98C1000 122 1100 110 1150 104L1200 98V134H1150C1100 134 1000 134 900 134C800 134 700 134 600 134C500 134 400 134 300 134C200 134 100 134 50 134H0V98Z' fill='black'/></svg>");
+    box-shadow: 10px 10px 10px 10px rgba(0, 0, 0, 0.1);
+  }
+
+  @media (max-width: 850px) {
+    .wave-container::before {
+      height: 7.5px;
+    }
+  }
+</style>

--- a/src/sections/Gallery.astro
+++ b/src/sections/Gallery.astro
@@ -2,7 +2,10 @@
 import { galleryImages } from "@/consts/galleryImages"
 
 import { Image } from "astro:assets"
+import WaveSeparator from "@/components/WaveSeparator.astro"
 ---
+
+<WaveSeparator bottomColor="var(--color-theme-blue)" />
 
 <section class="bg-theme-blue px-6 py-16 lg:px-8">
   <div class="mx-auto max-w-6xl" id="gallery">
@@ -65,6 +68,8 @@ import { Image } from "astro:assets"
     </div>
   </div>
 </section>
+
+<WaveSeparator bottomColor="var(--color-primary)" />
 
 <script>
   const galleryItems = document.querySelectorAll("#gallery li img") as NodeListOf<HTMLImageElement>


### PR DESCRIPTION
Siguiendo la línea de @restoker en su #90 se añaden unas olas en la galería.

---

## Tipo de cambio

Marca las opciones relevantes para esta PR:

- [ ] Corrección de errores (cambio no disruptivo que soluciona un problema)
- [x] Nueva funcionalidad (cambio no disruptivo que añade una nueva funcionalidad)
- [ ] Cambio disruptivo (corrección o funcionalidad que causa que una funcionalidad existente no funcione como se espera)
- [ ] Mejora de documentación

---

## ¿Se han realizado tests automáticos?

- [ ] Sí
- [x] No

---

## Capturas de pantalla

| Antes | Despues |
| - | - |
| ![image](https://github.com/user-attachments/assets/91ada6b1-2a94-4bba-8492-bba4ce3ed4db) | ![image](https://github.com/user-attachments/assets/cd8736f5-f6b6-4f09-819c-293dec620e79) | 
| ![image](https://github.com/user-attachments/assets/e2ffa3b7-ba80-484b-bca5-9791cd28636e) | ![image](https://github.com/user-attachments/assets/84d86d27-0220-4d3a-887c-f65394445653) |
