### PR TITLE
feat: add arrow key navigation to gallery lightbox

### DIFF
--- a/src/sections/Gallery.astro
+++ b/src/sections/Gallery.astro
@@ -16,10 +16,11 @@ import { Image } from "astro:assets"
       class="grid grid-cols-1 gap-8 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 [&>*:nth-child(even)]:rotate-2 [&>*:nth-child(n)]:hover:scale-105 [&>*:nth-child(n)]:hover:rotate-0 [&>*:nth-child(n)]:hover:shadow-xl [&>*:nth-child(odd)]:rotate-[-2deg]"
     >
       {
-        galleryImages.map(({ image, alt, thumb }) => (
+        galleryImages.map(({ image, alt, thumb }, index) => (
           <li
             id={thumb}
             class="aspect-9/10 cursor-pointer rounded-md shadow-sm transition-transform duration-300 will-change-transform"
+            data-index={index}
           >
             <Image
               src={image}
@@ -45,7 +46,7 @@ import { Image } from "astro:assets"
       <button
         type="button"
         id="close-lightbox"
-        class="hover:text-primary absolute -top-8 -right-1 -m-2.5 cursor-pointer rounded-full bg-white p-2.5 text-gray-700 transition-all duration-300 ease-in will-change-transform hover:scale-125"
+        class="hover:text-primary absolute top-1 -right-16 z-[999999] cursor-pointer rounded-full bg-white p-2.5 text-gray-700 transition-all duration-300 ease-in will-change-transform hover:scale-125 sm:top-6 sm:right-6 md:top-8 md:right-8"
       >
         <span class="sr-only">Cerrar Galería</span>
         <svg
@@ -67,12 +68,21 @@ import { Image } from "astro:assets"
 </section>
 
 <script>
-  const galleryItems = document.querySelectorAll("#gallery li img") as NodeListOf<HTMLImageElement>
+  const galleryItems = Array.from(
+    document.querySelectorAll("#gallery li img")
+  ) as HTMLImageElement[]
   const lightBox = document.getElementById("lightbox") as HTMLDivElement
   const lightBoxImgContainer = document.getElementById("light-box-content") as HTMLDivElement
   const btnCloseLightBox = document.getElementById("close-lightbox") as HTMLButtonElement
 
-  const openLightBox = (image: HTMLImageElement) => {
+  let currentIndex = 0
+
+  const openLightBox = (index: number) => {
+    if (index < 0 || index >= galleryItems.length) return
+    currentIndex = index
+    const image = galleryItems[index].cloneNode() as HTMLImageElement
+    image.style.viewTransitionName = ""
+    lightBoxImgContainer.innerHTML = ""
     lightBoxImgContainer.appendChild(image)
     lightBox.classList.remove("opacity-0", "pointer-events-none")
     lightBox.classList.add(
@@ -85,7 +95,8 @@ import { Image } from "astro:assets"
 
     document.body.style.overflow = "hidden"
   }
-  const closeLightBox = (image: HTMLImageElement) => {
+
+  const closeLightBox = () => {
     lightBox.classList.add("opacity-0", "pointer-events-none")
     lightBox.classList.remove(
       "bg-[#ff0693a4]",
@@ -94,75 +105,65 @@ import { Image } from "astro:assets"
       "pointer-events-auto",
       "backdrop-blur-[10px]"
     )
-    const galleryParentID = image.getAttribute("data-thumbID")
-    const galleryParent = document.getElementById(`${galleryParentID}`) as HTMLLIElement
-    galleryParent.appendChild(image)
 
     lightBoxImgContainer.innerHTML = "" // Elimina la imagen ampliada
     document.body.style.overflow = "" // Restaurar scroll
   }
 
-  galleryItems.forEach((eachItem) => {
-    eachItem.addEventListener("click", (event) => {
-      const image = event.target as HTMLImageElement
+  const navigateLightBox = (direction: number) => {
+    let newIndex = currentIndex + direction
+    if (newIndex < 0 || newIndex >= galleryItems.length) return
+
+    openLightBox(newIndex)
+  }
+
+  galleryItems.forEach((image, index) => {
+    image.addEventListener("click", () => {
       if (!document.startViewTransition) {
-        openLightBox(image)
+        openLightBox(index)
         return
       }
 
+      galleryItems.forEach((img) => {
+        img.style.viewTransitionName = ""
+      })
+
       image.style.viewTransitionName = "selected-img"
+
       document.startViewTransition(() => {
-        openLightBox(image)
+        openLightBox(index)
       })
     })
   })
 
-  lightBox.addEventListener("click", async () => {
-    const image = lightBoxImgContainer.querySelector("img") as HTMLImageElement
+  const handleClose = async () => {
+    if (!lightBoxImgContainer.querySelector("img")) return
+
     if (!document.startViewTransition) {
-      closeLightBox(image)
+      closeLightBox()
       return
     }
 
     const animation = document.startViewTransition(() => {
-      closeLightBox(image)
+      closeLightBox()
     })
 
     await animation.finished
-    image.style.viewTransitionName = "none"
-  })
+  }
 
-  btnCloseLightBox.addEventListener("click", async (event) => {
+  lightBox.addEventListener("click", handleClose)
+  btnCloseLightBox.addEventListener("click", (event) => {
     event.stopPropagation()
-    const image = btnCloseLightBox.nextElementSibling!.querySelector("img") as HTMLImageElement
-    if (!document.startViewTransition) {
-      closeLightBox(image)
-      return
-    }
-
-    const animation = document.startViewTransition(() => {
-      closeLightBox(image)
-    })
-
-    await animation.finished
-    image.style.viewTransitionName = "none"
+    handleClose()
   })
 
   document.addEventListener("keydown", async (event) => {
     if (event.key === "Escape") {
-      const image = lightBoxImgContainer.querySelector("img") as HTMLImageElement
-
-      if (!document.startViewTransition) {
-        closeLightBox(image)
-        return
-      }
-
-      const animation = document.startViewTransition(() => {
-        closeLightBox(image)
-      })
-
-      await animation.finished
-      image.style.viewTransitionName = "none"
+      await handleClose()
+    } else if (event.key === "ArrowRight") {
+      navigateLightBox(1)
+    } else if (event.key === "ArrowLeft") {
+      navigateLightBox(-1)
     }
   })
 </script>


### PR DESCRIPTION
# feat: add arrow key navigation to gallery lightbox

## ¿Qué se ha hecho en esta PR?

Se ha añadido la navegación con teclas de flecha (`←` y `→`) en la lightbox de la galería, permitiendo a los usuarios desplazarse entre imágenes sin necesidad de hacer clic manualmente.

Esto mejora la experiencia de usuario, proporcionando una interacción más fluida e intuitiva dentro de la galería.

**Arregla:** No aplica

---

## Tipo de cambio

- [ ] Corrección de errores (cambio no disruptivo que soluciona un problema)  
- [x] Nueva funcionalidad (cambio no disruptivo que añade una nueva funcionalidad)  
- [ ] Cambio disruptivo (corrección o funcionalidad que causa que una funcionalidad existente no funcione como se espera)  
- [ ] Mejora de documentación  

---

## ¿Se han realizado tests automáticos?

- [ ] Sí  
- [x] No  

---

## ¿Cuál es el comportamiento esperado tras el cambio?

Al abrir una imagen en la lightbox, los usuarios pueden usar las teclas de flecha izquierda (`←`) y derecha (`→`) para navegar entre las imágenes.
Esto mejora la accesibilidad y usabilidad de la galería.

---

## ¿Cómo se pueden testear las características introducidas en esta PR?

1. Abrir la galería y seleccionar una imagen para abrir la lightbox.  
2. Usar la tecla `→` para pasar a la siguiente imagen.  
3. Usar la tecla `←` para volver a la imagen anterior.  
4. Verificar que la navegación con teclas funciona correctamente y sin errores.  

---

## Capturas de pantalla

https://github.com/user-attachments/assets/64390e32-c387-4654-8b1a-64be0c3f52fb

---

## Enlaces adicionales

No hay enlaces adicionales.
