### PR TITLE
improvement: make responsibility document link open in new tab

### DIFF
--- a/src/sections/FAQ.astro
+++ b/src/sections/FAQ.astro
@@ -30,7 +30,8 @@ import { Image } from "astro:assets"
               parte del adulto. <a
                 class="bg-primary-light hover:text-primary inline-block max-w-full rounded-lg p-1 px-2 text-center break-words text-white transition hover:bg-white"
                 href="/hoja-de-responsabilidad.pdf"
-                >Descarga el documento y llévalo firmado al evento.</a
+                target="_blank"
+                rel="noopener noreferrer">Descarga el documento y llévalo firmado al evento.</a
               >
             </dd>
           </div>


### PR DESCRIPTION
## ¿Qué se ha hecho en esta PR?

Se ha modificado el enlace al documento de responsabilidad para que se abra en una nueva pestaña del navegador.
Para ello, se ha añadido el atributo target="_blank" junto con rel="noopener noreferrer" para mejorar la experiencia del usuario y aplicar buenas prácticas de seguridad.

**Arregla:** No aplica.

---

## Tipo de cambio

Marca las opciones relevantes para esta PR:

- [ ] Corrección de errores (cambio no disruptivo que soluciona un problema)
- [X] Nueva funcionalidad (cambio no disruptivo que añade una nueva funcionalidad)
- [ ] Cambio disruptivo (corrección o funcionalidad que causa que una funcionalidad existente no funcione como se espera)
- [ ] Mejora de documentación

---

## ¿Se han realizado tests automáticos?

- [ ] Sí
- [X] No

---

## ¿Cuál es el comportamiento esperado tras el cambio?

Al hacer clic en el enlace del documento de responsabilidad, este se abrirá en una nueva pestaña en lugar de la misma ventana, mejorando la navegación del usuario.

---

## ¿Cómo se pueden testear las características introducidas en esta PR?

Hacer clic en el enlace del documento de responsabilidad en la sección de preguntas frecuentes.
Verificar que el documento se abre en una nueva pestaña.

---
