### PR TITLE
feat: add prev/next buttons to navigate through images in lightbox

### DIFF
--- a/src/sections/Gallery.astro
+++ b/src/sections/Gallery.astro
@@ -65,6 +65,20 @@ import WaveSeparator from "@/components/WaveSeparator.astro"
         </svg>
       </button>
 
+      <button
+        id="prev-image"
+        class="hover:text-primary absolute top-1/2 -left-16 z-50 flex h-12 w-12 -translate-y-1/2 transform cursor-pointer items-center justify-center rounded-full bg-white p-2.5 text-2xl text-gray-700 transition-all duration-300 ease-in-out hover:scale-125"
+      >
+        &#60;
+      </button>
+
+      <button
+        id="next-image"
+        class="hover:text-primary absolute top-1/2 -right-16 z-50 flex h-12 w-12 -translate-y-1/2 transform cursor-pointer items-center justify-center rounded-full bg-white p-2.5 text-2xl text-gray-700 transition-all duration-300 ease-in-out hover:scale-125"
+      >
+        &#62;
+      </button>
+
       <figure id="light-box-content"></figure>
     </div>
   </div>
@@ -79,6 +93,8 @@ import WaveSeparator from "@/components/WaveSeparator.astro"
   const lightBox = document.getElementById("lightbox") as HTMLDivElement
   const lightBoxImgContainer = document.getElementById("light-box-content") as HTMLDivElement
   const btnCloseLightBox = document.getElementById("close-lightbox") as HTMLButtonElement
+  const btnPrev = document.getElementById("prev-image") as HTMLButtonElement
+  const btnNext = document.getElementById("next-image") as HTMLButtonElement
 
   let currentIndex = 0
 
@@ -108,6 +124,7 @@ import WaveSeparator from "@/components/WaveSeparator.astro"
     )
 
     document.body.style.overflow = "hidden"
+    updateNavigationButtons()
   }
 
   const closeLightBox = (image: HTMLImageElement) => {
@@ -138,6 +155,13 @@ import WaveSeparator from "@/components/WaveSeparator.astro"
     document.startViewTransition(() => {
       openLightBox(newIndex)
     })
+  }
+
+  const updateNavigationButtons = () => {
+    if (btnPrev && btnNext) {
+      btnPrev.style.display = currentIndex > 0 ? "flex" : "none"
+      btnNext.style.display = currentIndex < galleryItems.length - 1 ? "flex" : "none"
+    }
   }
 
   galleryItems.forEach((image, index) => {
@@ -181,6 +205,18 @@ import WaveSeparator from "@/components/WaveSeparator.astro"
     event.stopPropagation()
     handleClose()
   })
+
+  if (btnPrev && btnNext) {
+    btnPrev.addEventListener("click", (event) => {
+      event.stopPropagation()
+      navigateLightBox(-1)
+    })
+
+    btnNext.addEventListener("click", (event) => {
+      event.stopPropagation()
+      navigateLightBox(1)
+    })
+  }
 
   document.addEventListener("keydown", async (event) => {
     if (event.key === "Escape") {


### PR DESCRIPTION
## ¿Qué se ha hecho en esta PR?

Se ha añadido la funcionalidad de navegación con los botones de anterior y siguiente dentro del lightbox para permitir a los usuarios desplazarse entre las imágenes de la galería de manera más fluida. Estos botones se muestran y ocultan automáticamente según la posición de la imagen actual, mejorando la experiencia de usuario.

**Arregla:** No aplica.

---

## Tipo de cambio

Marca las opciones relevantes para esta PR:

- [ ] Corrección de errores (cambio no disruptivo que soluciona un problema)
- [X] Nueva funcionalidad (cambio no disruptivo que añade una nueva funcionalidad)
- [ ] Cambio disruptivo (corrección o funcionalidad que causa que una funcionalidad existente no funcione como se espera)
- [ ] Mejora de documentación

---

## ¿Se han realizado tests automáticos?

- [ ] Sí
- [X] No

---

## ¿Cuál es el comportamiento esperado tras el cambio?

Ahora, los botones añadidos permiten navegar entre las imágenes de la galería dentro del lightbox. Los botones se ocultan cuando no hay más imágenes hacia la izquierda o derecha.

---

## ¿Cómo se pueden testear las características introducidas en esta PR?

Abrir el lightbox al hacer clic en una imagen de la galería.
Verificar que los botones aparezcan y funcionen correctamente según la posición de la imagen.
Asegurarse de que los botones se oculten cuando no haya más imágenes hacia la izquierda o derecha.

---

## Capturas de pantalla

![Screenshot 2025-03-19 143416](https://github.com/user-attachments/assets/7bdc484e-396e-4881-9238-4c1afd633969)
