### PR TITLE
fix: sponsors' background is no longer getting scaled

### DIFF
--- a/src/sections/Sponsors.astro
+++ b/src/sections/Sponsors.astro
@@ -9,10 +9,10 @@ import WaveSeparator from "@/components/WaveSeparator.astro"
 import { Image } from "astro:assets"
 ---
 
-<section
-  class="view-animate-[--subjectReveal] animate-zoom-in animate-range-[entry_15%_contain_25%] bg-theme-blue py-24 sm:py-32"
->
-  <div class="mx-auto max-w-7xl px-6 lg:px-8">
+<section class="bg-theme-blue py-24 sm:py-32">
+  <div
+    class="view-animate-[--subjectReveal] animate-zoom-in animate-range-[entry_15%_contain_25%] mx-auto max-w-7xl px-6 lg:px-8"
+  >
     <h2 class="text-center text-lg/8 font-semibold text-white">
       ¡Con el apoyo de empresas increíbles! 🚀
     </h2>


### PR DESCRIPTION
## ¿Qué se ha hecho en esta PR?

Arreglado el fondo azul de la sección de sponsors reescalándose al hacer scroll.

**Arregla:** No aplica.

---

## Tipo de cambio

Marca las opciones relevantes para esta PR:

- [X] Corrección de errores (cambio no disruptivo que soluciona un problema)
- [ ] Nueva funcionalidad (cambio no disruptivo que añade una nueva funcionalidad)
- [ ] Cambio disruptivo (corrección o funcionalidad que causa que una funcionalidad existente no funcione como se espera)
- [ ] Mejora de documentación

---

## ¿Se han realizado tests automáticos?

- [ ] Sí
- [X] No

---

## ¿Cuál es el comportamiento esperado tras el cambio?

El fondo azul de la sección de sponsors mantiene su tamaño a pesar de la animación.

---

## ¿Cómo se pueden testear las características introducidas en esta PR?

Hacer scroll cerca de la sección de sponsors.

---

## Capturas de pantalla

Antes:
![chrome_d3z8ItW452](https://github.com/user-attachments/assets/5da5d19e-135b-4d29-8c34-7aebe589e3d8)
Después:
![chrome_f8RS3GjYbd](https://github.com/user-attachments/assets/5a81fdc5-e69c-403b-9ebf-a7af5d41c02b)


---

## Enlaces adicionales

No hay enlaces adicionales.