### PR TITLE
fix: hyperlink hover on FAQ now matches the other

### DIFF
--- a/src/sections/FAQ.astro
+++ b/src/sections/FAQ.astro
@@ -92,7 +92,7 @@ import { Image } from "astro:assets"
               Sí, los menores de edad pueden asistir al evento siempre y cuando estén acompañados
               por un adulto. Además, se requiere la firma de un documento de responsabilidad por
               parte del adulto. <a
-                class="bg-primary-light hover:text-primary inline-block max-w-full rounded-lg p-1 px-2 text-center break-words text-white transition hover:bg-white"
+                class="bg-primary-light hover:text-primary inline-block max-w-full rounded-lg p-1 px-2 text-center break-words text-white transition hover:bg-white/85"
                 href="/hoja-de-responsabilidad.pdf"
                 target="_blank"
                 rel="noopener noreferrer">Descarga el documento y llévalo firmado al evento.</a
@@ -135,7 +135,6 @@ import { Image } from "astro:assets"
     </div>
   </div>
 </section>
-
 
 <style>
   body:has(.card[data-color="have"]:hover) {


### PR DESCRIPTION
## ¿Qué se ha hecho en esta PR?

Cambio de estilo del hiperlink en la sección de FAQ para que sea igual que el de la sección de Map.

---

## Tipo de cambio

Marca las opciones relevantes para esta PR:

- [X] Corrección de errores (cambio no disruptivo que soluciona un problema)
- [ ] Nueva funcionalidad (cambio no disruptivo que añade una nueva funcionalidad)
- [ ] Cambio disruptivo (corrección o funcionalidad que causa que una funcionalidad existente no funcione como se espera)
- [ ] Mejora de documentación

---

## ¿Se han realizado tests automáticos?

- [ ] Sí
- [X] No

---

## ¿Cuál es el comportamiento esperado tras el cambio?

El hiperlink en la sección de FAQ en hover ahora se ve igual que el de la sección de Map.

---

## ¿Cómo se pueden testear las características introducidas en esta PR?

Pasar el ratón por encima del hiperlink.

---

## Capturas de pantalla
Antes:
![Screenshot 2025-03-19 170323](https://github.com/user-attachments/assets/18e5da18-9461-4f3b-aaff-eb4ff0865134)
Después:
![Screenshot 2025-03-19 170401](https://github.com/user-attachments/assets/6b9faf54-c3ea-4014-9cf8-1c082a346067)


---

## Enlaces adicionales

No hay enlaces adicionales.