### PR TITLE
fix: control zoom no longer goes over header

### DIFF
--- a/src/components/LeafletMap.astro
+++ b/src/components/LeafletMap.astro
@@ -92,6 +92,10 @@ const { latitude, longitude, zoom, tileLayer, attribution, geoJSON } = Astro.pro
     z-index: 10;
   }
 
+  .leaflet-top {
+    z-index: 11;
+  }
+
   .leaflet-control-zoom.leaflet-bar.leaflet-control {
     border-radius: 24px;
     overflow: hidden;


### PR DESCRIPTION
## ¿Qué se ha hecho en esta PR?

Cambiado el z index del controlador de zoom del mapa.

---

## Tipo de cambio

Marca las opciones relevantes para esta PR:

- [X] Corrección de errores (cambio no disruptivo que soluciona un problema)
- [ ] Nueva funcionalidad (cambio no disruptivo que añade una nueva funcionalidad)
- [ ] Cambio disruptivo (corrección o funcionalidad que causa que una funcionalidad existente no funcione como se espera)
- [ ] Mejora de documentación

---

## ¿Se han realizado tests automáticos?

- [ ] Sí
- [X] No

---

## ¿Cuál es el comportamiento esperado tras el cambio?

El controlador de zoom del mapa ya no estará por encima del header.

---

## ¿Cómo se pueden testear las características introducidas en esta PR?

Scroll en la sección del mapa.

---

## Capturas de pantalla
Antes:
![Screenshot 2025-03-19 173421](https://github.com/user-attachments/assets/182539e1-ea37-4f39-ba07-e51d4d87a49b)
Después:
![Screenshot 2025-03-19 173416](https://github.com/user-attachments/assets/91a45e9c-4ba3-4069-a1bd-e241563f7634)

---

## Enlaces adicionales

No hay enlaces adicionales.