### PR TITLE
Fix/restrict arrow navigation

### DIFF
--- a/src/components/StarryBackground.astro
+++ b/src/components/StarryBackground.astro
@@ -1,0 +1,41 @@
+---
+const starCount = 120
+const minDistance = 5
+
+// Función para calcular la distancia entre dos puntos
+const getDistance = (x1: number, y1: number, x2: number, y2: number) => {
+  return Math.sqrt((x2 - x1) ** 2 + (y2 - y1) ** 2)
+}
+
+const stars: any[] = []
+
+while (stars.length < starCount) {
+  const newStar = {
+    top: Math.random() * 95,
+    left: Math.random() * 100,
+    size: Math.random() * 6 + 10, // Tamaño entre 10 y 16 px
+    opacity: Math.random() * 0.2 + 0.5, // Opacidad entre 0.5 y 1
+    rotation: Math.random() * 360, // Rotación entre 0 y 360 grados
+  }
+
+  // Verificar que la nueva estrella no esté demasiado cerca de otra
+  if (
+    stars.every(
+      (star) => getDistance(star.left, star.top, newStar.left, newStar.top) >= minDistance
+    )
+  ) {
+    stars.push(newStar)
+  }
+}
+---
+
+<div class="pointer-events-none absolute inset-0">
+  {
+    stars.map((star, index) => (
+      <div
+        class="bg-primary-light absolute animate-pulse shadow-[0_0_6px_rgba(255,182,193,0.8)]"
+        style={`top: ${star.top}%; left: ${star.left}%; width: ${star.size}px; height: ${star.size}px; opacity: ${star.opacity}; transform: rotate(${star.rotation}deg); clip-path: polygon(50% 0%, 61% 35%, 98% 35%, 68% 57%, 79% 91%, 50% 70%, 21% 91%, 32% 57%, 2% 35%, 39% 35%);`}
+      />
+    ))
+  }
+</div>

--- a/src/sections/Gallery.astro
+++ b/src/sections/Gallery.astro
@@ -2,12 +2,14 @@
 import { galleryImages } from "@/consts/galleryImages"
 
 import { Image } from "astro:assets"
+import StarryBackground from "@/components/StarryBackground.astro"
 import WaveSeparator from "@/components/WaveSeparator.astro"
 ---
 
 <WaveSeparator bottomColor="var(--color-theme-blue)" />
 
-<section class="bg-theme-blue px-6 py-16 lg:px-8">
+<section class="bg-theme-blue relative px-6 py-16 lg:px-8">
+  <StarryBackground />
   <div class="mx-auto max-w-6xl" id="gallery">
     <div class="relative mb-12 flex items-center justify-center">
       <h2

--- a/src/sections/Gallery.astro
+++ b/src/sections/Gallery.astro
@@ -194,12 +194,14 @@ import WaveSeparator from "@/components/WaveSeparator.astro"
   })
 
   document.addEventListener("keydown", async (event) => {
+    const isLightboxOpen = !lightBox.classList.contains("opacity-0")
+
     if (event.key === "Escape") {
       await handleClose()
-    } else if (event.key === "ArrowRight" || event.key === "d") {
+    } else if ((event.key === "ArrowRight" || event.key === "d") && isLightboxOpen) {
       event.preventDefault()
       navigateLightBox(1)
-    } else if (event.key === "ArrowLeft" || event.key === "a") {
+    } else if ((event.key === "ArrowLeft" || event.key === "a") && isLightboxOpen) {
       event.preventDefault()
       navigateLightBox(-1)
     }

--- a/src/sections/Sponsors.astro
+++ b/src/sections/Sponsors.astro
@@ -5,13 +5,15 @@ import Donnetes from "@/assets/donettes.png"
 import InfoJobs from "@/assets/infojobs.svg"
 import Trolli from "@/assets/trolli.png"
 
+import StarryBackground from "@/components/StarryBackground.astro"
 import WaveSeparator from "@/components/WaveSeparator.astro"
 import { Image } from "astro:assets"
 ---
 
 <WaveSeparator bottomColor="var(--color-theme-blue)" />
 
-<section class="bg-theme-blue py-24 sm:py-32">
+<section class="bg-theme-blue relative py-24 sm:py-32">
+  <StarryBackground />
   <div
     class="view-animate-[--subjectReveal] animate-zoom-in animate-range-[entry_15%_contain_25%] mx-auto max-w-7xl px-6 lg:px-8"
   >


### PR DESCRIPTION
## ¿Qué se ha hecho en esta PR?

Se ha corregido la navegación con flechas en la galería de imágenes, evitando que los usuarios puedan moverse entre imágenes cuando el lightbox está cerrado.  
Ahora, solo se podrá usar las teclas **"ArrowRight"** y **"ArrowLeft"** si hay una imagen abierta en el lightbox.  

**Arregla:** No hay issue relacionado.

---

## Tipo de cambio  

Marca las opciones relevantes para esta PR:  

- [x] Corrección de errores (cambio no disruptivo que soluciona un problema)  
- [ ] Nueva funcionalidad (cambio no disruptivo que añade una nueva funcionalidad)  
- [ ] Cambio disruptivo (corrección o funcionalidad que causa que una funcionalidad existente no funcione como se espera)  
- [ ] Mejora de documentación  

---

## ¿Se han realizado tests automáticos?  

- [ ] Sí  
- [x] No  

---

## ¿Cuál es el comportamiento esperado tras el cambio?  

El usuario solo podrá navegar con las flechas si el **lightbox está abierto**.  
Si el lightbox está **cerrado**, las teclas de navegación no tendrán efecto.  

---

## ¿Cómo se pueden testear las características introducidas en esta PR?  

1. Abrir la galería de imágenes.  
2. Comprobar que se puede navegar con las flechas cuando el **lightbox está abierto**.  
3. Cerrar el lightbox y verificar que las flechas **ya no permiten moverse**.  

---

## Capturas de pantalla  

No se requieren capturas de pantalla.  

---

## Enlaces adicionales  

No hay enlaces adicionales.  

---