### PR TITLE
fix: improve text readability on FAQ card hover state

### DIFF
--- a/src/sections/FAQ.astro
+++ b/src/sections/FAQ.astro
@@ -142,6 +142,13 @@ import { Image } from "astro:assets"
     transition: 0.5s ease-in-out;
   }
 
+  body:has(.card[data-color="have"]:hover) h2,
+  body:has(.card[data-color="have"]:hover) dt,
+  body:has(.card[data-color="have"]:hover) dd,
+  body:has(.card[data-color="have"]:hover) a {
+    color: #393941;
+  }
+
   .card {
     background-size: cover;
     background-position: center;


### PR DESCRIPTION
## ¿Qué se ha hecho en esta PR?

- Se ha actualizado el contraste del texto en las preguntas frecuentes (FAQ) para garantizar una mejor legibilidad cuando el fondo cambia a azul claro al pasar el cursor sobre la imagen. 
- Además, se han actualizado los colores del texto para todo el contenido de las FAQ, incluyendo encabezados, preguntas y respuestas.

---

## Tipo de cambio

Marca las opciones relevantes para esta PR:

- [x] Corrección de errores (cambio no disruptivo que soluciona un problema)
- [ ] Nueva funcionalidad (cambio no disruptivo que añade una nueva funcionalidad)
- [ ] Cambio disruptivo (corrección o funcionalidad que causa que una funcionalidad existente no funcione como se espera)
- [ ] Mejora de documentación

---

## ¿Se han realizado tests automáticos?

- [ ] Sí
- [x] No

---

## ¿Cuál es el comportamiento esperado tras el cambio?

Los textos en la sección de FAQ serán más legibles cuando el fondo cambie a azul claro, evitando problemas de contraste.
Este cambio mejora la accesibilidad sin afectar la funcionalidad del producto.

---

## ¿Cómo se pueden testear las características introducidas en esta PR?

1. Ir a la sección de preguntas frecuentes (FAQ).
2. Pasar el cursor sobre las imágenes de las tarjetas.
3. Verificar que el texto sigue siendo legible cuando el fondo cambia a azul claro.

---

## Capturas de pantalla

Antes:
![image](https://github.com/user-attachments/assets/d6e0cbbc-788e-4798-b164-efd322ba86e4)

Despues:
![image](https://github.com/user-attachments/assets/871eddb6-947d-4f5e-9a20-327a23c4b72a)

---

## Enlaces adicionales

No hay enlaces adicionales.