### PR TITLE
feat: add mobile menu close functionality when tapping outside

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -130,6 +130,15 @@
   // Add event listener to close menu button
   closeMenuButton?.addEventListener("click", toggleMenu)
 
+  document.addEventListener("click", (event) => {
+    const isClickInsideMenu = mobileMenu.contains(event.target as Node)
+    const isClickInsideButton = openMenuButton?.contains(event.target as Node)
+
+    if (isClickInsideMenu && !isClickInsideButton) {
+      mobileMenu.close()
+    }
+  })
+
   mobileItems?.forEach((item) => item.addEventListener("click", toggleMenu))
 </script>
 


### PR DESCRIPTION
## ¿Qué se ha hecho en esta PR?

Se ha implementado la funcionalidad que permite cerrar el menú móvil al hacer clic o tocar fuera de él.

**Arregla:** No aplica.

---

## Tipo de cambio

Marca las opciones relevantes para esta PR:

- [ ] Corrección de errores (cambio no disruptivo que soluciona un problema)
- [X] Nueva funcionalidad (cambio no disruptivo que añade una nueva funcionalidad)
- [ ] Cambio disruptivo (corrección o funcionalidad que causa que una funcionalidad existente no funcione como se espera)
- [ ] Mejora de documentación

---

## ¿Se han realizado tests automáticos?

- [ ] Sí
- [X] No

---

## ¿Cuál es el comportamiento esperado tras el cambio?

Ahora el menú se cierra automáticamente cuando se interactúa con áreas fuera del menú, sin necesidad de usar el botón de cierre.

---

## ¿Cómo se pueden testear las características introducidas en esta PR?

Hacer tap o click fuera del menú en móvil.

---

## Capturas de pantalla

![chrome_6rq8TgiDQ6](https://github.com/user-attachments/assets/f0a7ace0-17fe-4907-96a3-792a3f4f5dd8)

---

## Enlaces adicionales

No hay enlaces adicionales.