### PR TITLE
fix: prev/next buttons on gallery not visible on smaller devices

### DIFF
--- a/src/sections/Gallery.astro
+++ b/src/sections/Gallery.astro
@@ -78,14 +78,14 @@ import WaveSeparator from "@/components/WaveSeparator.astro"
 
       <button
         id="prev-image"
-        class="hover:text-primary absolute top-1/2 -left-16 z-50 flex h-12 w-12 -translate-y-1/2 transform cursor-pointer items-center justify-center rounded-full bg-white p-2.5 text-2xl text-gray-700 transition-all duration-300 ease-in-out hover:scale-125"
+        class="hover:text-primary absolute -bottom-16 left-8 z-50 flex h-12 w-12 transform cursor-pointer items-center justify-center rounded-full bg-white p-2.5 text-2xl text-gray-700 transition-all duration-300 ease-in-out hover:scale-125 md:top-1/2 md:-translate-y-1/2 lg:-left-16"
       >
         &#60;
       </button>
 
       <button
         id="next-image"
-        class="hover:text-primary absolute top-1/2 -right-16 z-50 flex h-12 w-12 -translate-y-1/2 transform cursor-pointer items-center justify-center rounded-full bg-white p-2.5 text-2xl text-gray-700 transition-all duration-300 ease-in-out hover:scale-125"
+        class="hover:text-primary absolute right-8 -bottom-16 z-50 flex h-12 w-12 transform cursor-pointer items-center justify-center rounded-full bg-white p-2.5 text-2xl text-gray-700 transition-all duration-300 ease-in-out hover:scale-125 md:top-1/2 md:-translate-y-1/2 lg:-right-16"
       >
         &#62;
       </button>


### PR DESCRIPTION
## ¿Qué se ha hecho en esta PR?

Reposicionado los botones para cambiar de imagen en la galería para que sean visibles y funcionales en pantallas más pequeñas.

**Arregla:** No aplica.

---

## Tipo de cambio

Marca las opciones relevantes para esta PR:

- [X] Corrección de errores (cambio no disruptivo que soluciona un problema)
- [ ] Nueva funcionalidad (cambio no disruptivo que añade una nueva funcionalidad)
- [ ] Cambio disruptivo (corrección o funcionalidad que causa que una funcionalidad existente no funcione como se espera)
- [ ] Mejora de documentación

---

## ¿Se han realizado tests automáticos?

- [ ] Sí
- [X] No

---

## ¿Cuál es el comportamiento esperado tras el cambio?

Los botones para cambiar de imagen en la galería aparecen en pantallas más pequeñas que lg.

---

## ¿Cómo se pueden testear las características introducidas en esta PR?

Cambiar resolución y comprobar que aparecen los botones.

---

## Capturas de pantalla

No se requieren capturas de pantalla.

---

## Enlaces adicionales

No hay enlaces adicionales.