### PR TITLE
fix: se corrige la transición del backdrop al accionar el nav

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -113,6 +113,9 @@
   </dialog>
 </header>
 
+<div id="backdrop"></div>
+
+
 <div data-target class="absolute top-[150px]"></div>
 
 <script>
@@ -121,9 +124,16 @@
   const openMenuButton = document.getElementById("open-menu-button")
   const closeMenuButton = document.getElementById("close-menu-button")
   const mobileItems = mobileMenu.querySelectorAll("a")
+  const backdrop = document.getElementById("backdrop");
 
   const toggleMenu = () => {
     mobileMenu.open ? mobileMenu.close() : mobileMenu.showModal()
+
+    if (mobileMenu.open) {
+        backdrop?.classList.add("visible")
+    } else {
+        backdrop?.classList.remove("visible")
+    }
   }
 
   // Add event listener to open menu button
@@ -138,6 +148,7 @@
 
     if (isClickInsideMenu && !isClickInsideButton) {
       mobileMenu.close()
+      backdrop?.classList.remove("visible")
     }
   })
 
@@ -174,5 +185,26 @@
 
   .end-state {
     @apply bg-primary/60 border-b-[#b50066] pb-6 backdrop-blur-md;
+  }
+
+  #backdrop {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    background-color: rgba(0, 0, 0, 0.5);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s ease-in-out;
+    z-index: 100;
+  }
+
+  #backdrop.visible {
+    opacity: 1;
+  }
+
+  dialog::backdrop {
+    display: none;
   }
 </style>


### PR DESCRIPTION
## ¿Qué se ha hecho en esta PR?

Se ha corregido la transición del backdrop que se activa al abrir el sidemenu en móviles, haciendo que no desaparezca repentinamente sino con una transición.

**Arregla:** No aplica.

---

## Tipo de cambio

Marca las opciones relevantes para esta PR:

- [X] Corrección de errores (cambio no disruptivo que soluciona un problema)
- [ ] Nueva funcionalidad (cambio no disruptivo que añade una nueva funcionalidad)
- [ ] Cambio disruptivo (corrección o funcionalidad que causa que una funcionalidad existente no funcione como se espera)
- [ ] Mejora de documentación

---

## ¿Se han realizado tests automáticos?

- [ ] Sí
- [X] No

---

## ¿Cuál es el comportamiento esperado tras el cambio?

Por ejemplo: 
No afecta al comportamiento del producto final.

---

## ¿Cómo se pueden testear las características introducidas en esta PR?

Por ejemplo: 
No es necesario realizar pruebas
---

## Capturas de pantalla

**Antes:**
https://github.com/user-attachments/assets/78235245-6da7-4be7-b7e2-d88a777becd8

**Después:**
https://github.com/user-attachments/assets/c54d6060-9781-4108-9e88-c4e556866163



---

## Enlaces adicionales
No hay enlaces adicionales.