### PR TITLE
fix: buy button now fits on small devices Header

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -3,7 +3,7 @@
     class="mx-auto flex max-w-6xl items-center justify-between px-4 py-6 pb-0 uppercase lg:px-8"
     aria-label="Global"
   >
-    <div class="flex flex-1">
+    <div class="flex">
       <div class="hidden lg:flex lg:gap-x-12">
         <a
           href="/#info"
@@ -201,7 +201,7 @@
     transition: opacity 0.3s ease-in-out;
     z-index: 100;
   }
-  
+
 
 
   .tickets-button {
@@ -210,7 +210,7 @@
     position: relative;
     overflow: hidden;
   }
-  
+
   .tickets-button::before {
     content: '';
     position: absolute;
@@ -222,12 +222,12 @@
     transform: rotate(30deg);
     animation: shine 3s linear infinite;
   }
-  
+
   @keyframes shimmer {
     0% { background-position: 0% 0; }
     100% { background-position: 200% 0; }
   }
-  
+
   @keyframes shine {
     0% { transform: translateX(-100%) rotate(30deg); }
     100% { transform: translateX(100%) rotate(30deg); }

--- a/src/sections/Hero.astro
+++ b/src/sections/Hero.astro
@@ -9,7 +9,7 @@ import DotBackground from "../components/DotBackground.astro"
   >
     <div
       title="Logo de Lola Lolita Land"
-      class="absolute top-15 right-0 left-0 z-50 mx-auto flex justify-center md:top-0 lg:top-14"
+      class="absolute top-20 right-0 left-0 z-50 mx-auto flex justify-center md:top-0 lg:top-14"
     >
       <div
         class="logo lazy_background_image_maskImage lazy_background_image relative size-56 md:size-44 lg:size-56"


### PR DESCRIPTION
## ¿Qué se ha hecho en esta PR?

Se ha quitado un flex-1 para que el botón de comprar tickets quepa bien en el Header en dispositivos pequeños.

---

## Tipo de cambio

Marca las opciones relevantes para esta PR:

- [X] Corrección de errores (cambio no disruptivo que soluciona un problema)
- [ ] Nueva funcionalidad (cambio no disruptivo que añade una nueva funcionalidad)
- [ ] Cambio disruptivo (corrección o funcionalidad que causa que una funcionalidad existente no funcione como se espera)
- [ ] Mejora de documentación

---

## ¿Se han realizado tests automáticos?

- [ ] Sí
- [X] No

---

## ¿Cuál es el comportamiento esperado tras el cambio?

No afecta al comportamiento del producto final.

---

## ¿Cómo se pueden testear las características introducidas en esta PR?

No es necesario realizar pruebas.

---

## Capturas de pantalla

Antes:
![Screenshot 2025-03-26 141403](https://github.com/user-attachments/assets/4c1d9826-f408-4ec5-b8d0-944654f34922)

Después:
![Screenshot 2025-03-26 141715](https://github.com/user-attachments/assets/5e7b08f0-5f9e-4663-9282-0d4f33e66b44)


---

## Enlaces adicionales

No hay enlaces adicionales.