### PR TITLE
Style: Banner Marque Tweak

### DIFF
--- a/src/components/Marquee.astro
+++ b/src/components/Marquee.astro
@@ -6,12 +6,14 @@ export type Props = {
 const { content } = Astro.props
 ---
 
-<div class="gap-x-4 py-2 flex overflow-hidden">
+<div class="flex gap-x-4 overflow-hidden py-8">
   {
     content.map((item, index) => (
-      <div class="marquee-content animate-marquee gap-x-4 flex-none justify-around flex [&>*]:uppercase [&>*]:font-black [&>*]:leading-none">
-        <div class="text-[5vh] md:text-[4vw]">{item}</div>
-        {index !== content.length - 1 && <div class="text-[5vh] md:text-[4vw]"> · </div>}
+      <div class="marquee-content animate-marquee flex flex-none justify-around gap-x-4 [&>*]:leading-none [&>*]:font-black [&>*]:uppercase">
+        <div class="text-[5vh] text-[#6c4bbc] md:text-[4vw]">{item}</div>
+        {index !== content.length - 1 && (
+          <div class="text-[5vh] text-[#6c4bbc] md:text-[4vw]"> · </div>
+        )}
       </div>
     ))
   }

--- a/src/sections/Tickets.astro
+++ b/src/sections/Tickets.astro
@@ -6,7 +6,7 @@ import Clock from "public/icons/clock.svg"
 ---
 
 <section class="relative w-full overflow-hidden" id="tickets">
-  <div class="bg-primary-light mx-auto my-[3%] -ml-2 w-[110%] -rotate-3 text-white">
+  <div class="bg-primary-light mx-auto my-[3%] -ml-2 w-[120%] -rotate-3 text-white">
     <Marquee
       content={[
         "Entradas",
@@ -78,7 +78,10 @@ import Clock from "public/icons/clock.svg"
               disabled
               class="tickets-button relative flex w-full cursor-not-allowed items-center justify-center gap-3 rounded-full bg-gradient-to-r from-[#ff0695] via-[#ff99d1] to-[#ff0695] px-4 py-3 font-bold text-white shadow-lg shadow-[#ff0695]/30 transition-all hover:scale-105 hover:shadow-xl hover:shadow-[#ff0695]/40"
             >
-              <Ticket title="ticket" class="hidden h-5 w-5 -rotate-12 animate-bounce fill-white sm:inline-block" />
+              <Ticket
+                title="ticket"
+                class="hidden h-5 w-5 -rotate-12 animate-bounce fill-white sm:inline-block"
+              />
               <span class="text-sm sm:text-base">Comprar entrada</span>
             </button>
           </div>
@@ -128,7 +131,10 @@ import Clock from "public/icons/clock.svg"
               disabled
               class="tickets-button relative flex w-full cursor-not-allowed items-center justify-center gap-3 rounded-full bg-gradient-to-r from-[#ff0695] via-[#ff99d1] to-[#ff0695] px-4 py-3 font-bold text-white shadow-lg shadow-[#ff0695]/30 transition-all hover:scale-105 hover:shadow-xl hover:shadow-[#ff0695]/40"
             >
-              <Ticket title="ticket" class="hidden h-5 w-5 -rotate-12 animate-bounce fill-white sm:inline-block" />
+              <Ticket
+                title="ticket"
+                class="hidden h-5 w-5 -rotate-12 animate-bounce fill-white sm:inline-block"
+              />
               <span class="text-sm sm:text-base">Comprar entrada</span>
             </button>
           </div>


### PR DESCRIPTION
Se ajustó el banner de entradas para mejorar su presencia visual y el contraste con el fondo.

---

### Cambios realizados

- Se aumentó el ancho de `110%` a `120%`
- Se incrementó el padding vertical de `py-2` a `py-8`
- El color del texto cambió de blanco (`text-white`) a azul `#383acf`, aplicado al título "Entradas" y los puntos separadores (`·`)

---

### Resultado

El banner ahora es más prominente, con mayor altura y un color que mejora la legibilidad sobre el fondo rosa claro.

Antes

![image](https://github.com/user-attachments/assets/81f37474-6fac-47a8-a029-d5a033fc35d6)


Después

![image](https://github.com/user-attachments/assets/5af9db24-8632-4daf-a85e-ddade28709bc)
