### PR TITLE
Ajustes de alignment en Info.astro

### DIFF
--- a/src/sections/Info.astro
+++ b/src/sections/Info.astro
@@ -67,10 +67,10 @@ import CalendarImage from "@/assets/images/calendario.webp"
             ¡Dos días de diversión!
           </p>
           <p class="mt-2 text-xs/5 text-pretty text-gray-600 sm:text-sm/6">
-            Apunta en tu calendario, porque LolaLolita Land abre sus puertas el 14 y 15 de junio
+            Apunta en tu calendario, porque LolaLolita Land abre sus puertas<br /> el 14 y 15 de junio
             para darle la bienvenida al verano.
           </p>
-          <div class="mt-4 flex justify-center">
+          <div class="mt-4 flex justify-start">
             <a
               class="bg-primary-light hover:text-primary hover:bg-primary-light/50 group inline-flex min-h-[38px] max-w-full items-center space-x-1 rounded-lg p-1 px-3 text-center text-xs/4 break-words text-white transition"
               href="https://calendar.google.com/calendar/render?action=TEMPLATE&text=Lola+Lolita+Land+🌸&dates=20250614/20250616&details=La+experiencia+más+refrescante.&location=Aquopolis+Villanueva+de+la+Cañada"
@@ -131,10 +131,10 @@ import CalendarImage from "@/assets/images/calendario.webp"
             Un parque acuático lleno de sorpresas
           </p>
           <p class="mt-2 text-xs/5 text-pretty text-gray-600 sm:text-sm/6">
-            Este año LolaLolita Land se celebra en Aquopolis, Madrid, un parque acuático lleno de
-            toboganes y piscinas.
+            Este año LolaLolita Land se celebra en Aquopolis, Madrid,<br /> un parque acuático lleno
+            de toboganes y piscinas.
           </p>
-          <div class="mt-4 flex flex-wrap justify-center gap-2">
+          <div class="mt-4 flex flex-wrap justify-between">
             <a
               class="bg-primary-light hover:text-primary hover:bg-primary-light/50 group inline-flex min-h-[38px] max-w-full items-center space-x-1 rounded-lg p-1 px-3 text-center text-xs/4 break-words text-white transition"
               href="https://villanueva.aquopolis.es/condiciones-de-contratacion"


### PR DESCRIPTION
Se realizaron ajustes visuales en la sección de información del evento para mejorar la alineación y la consistencia en la presentación.

---

### Cambios realizados

- **Alineación de botones:**
  - Los botones "Condiciones de contratación" y "Normas de funcionamiento" ahora se distribuyen uniformemente dentro del contenedor con `justify-between`
  - El botón "Añadir a Google Calendar" permanece alineado a la izquierda

- **Formato de texto:**
  - Se añadió un salto de línea (`<br />`) después de la palabra "el" en la descripción del evento para mejorar la legibilidad
    - Antes: `"abre sus puertas el 14 y 15 de junio..."`
    - Después: `"abre sus puertas el<br /> el 14 y 15 de junio..."`

Antes
![image](https://github.com/user-attachments/assets/f0034d16-bf86-4151-8c9b-bd351b2caf7a)

Después
![image](https://github.com/user-attachments/assets/e78045fb-813e-4922-b3d0-aff73201d634)
