### PR TITLE
Fix Duplicado en el Footer

### DIFF
--- a/src/sections/Footer.astro
+++ b/src/sections/Footer.astro
@@ -10,14 +10,18 @@ import TikTok from "../../public/icons/tiktok.svg"
     <div
       class="logo lazy_background_image_maskImage lazy_background_image relative size-28 lg:size-32"
     >
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="4.71132 2 10.58 15">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="4.71132 2 10.58 15"
+        role="img"
+        aria-labelledby="logoTitle"
+      >
+        <title id="logoTitle">Lola Lolita Land</title>
         <path
           d="M 5 2 L 15 2 C 16 3 14 4 15 5 C 16 6 14 7 15 8 C 16 9 14 10 15 11 C 16 12 14 13 15 14 C 16 15 14 16 15 17 L 5 17 C 4 16 6 15 5 14 C 4 13 6 12 5 11 C 4 10 6 9 5 8 C 4 7 6 6 5 5 C 4 4 6 3 5 2"
           fill="#383acf"></path>
       </svg>
     </div>
-
-    <p class="font-semibold text-white">Lola Lolita Land</p>
 
     <nav class="mt-6">
       <div class="grid grid-flow-col gap-4">


### PR DESCRIPTION
Se eliminó el texto duplicado "Lola Lolita Land" en el footer, ya que el logotipo ya contiene esa información visualmente. 
---

### Cambios realizados

- Eliminado el texto plano "Lola Lolita Land" en el **footer**
- Añadido `role="img"` al SVG para mejorar la semántica y accesibilidad
- Añadido `<title>Lola Lolita Land</title>` dentro del SVG para que lectores de pantalla puedan interpretarlo correctamente

Antes
![image](https://github.com/user-attachments/assets/0fb734ed-453b-45dd-8991-9dd812e8f612)

Después
![image](https://github.com/user-attachments/assets/87f5553c-6e2d-4dcc-9ba7-b78db8c6484f)
