### PR TITLE
Fix: Prevent gallery title line break on mobile to preserve animation

### DIFF
--- a/src/sections/Gallery.astro
+++ b/src/sections/Gallery.astro
@@ -13,12 +13,12 @@ import WaveSeparator from "@/components/WaveSeparator.astro"
   <div class="mx-auto max-w-6xl" id="gallery">
     <div class="relative mb-12 flex items-center justify-center">
       <h2
-        class="title mb-2 block p-4 text-center text-3xl font-bold text-white lg:text-4xl xl:text-5xl"
+        class="title mb-2 block p-4 text-center text-[1.65rem] font-bold text-white sm:text-sm lg:text-4xl xl:text-5xl"
       >
         ¡Así fue el año pasado!
       </h2>
       <h2
-        class="title2 mb-2 block p-4 text-center text-3xl font-bold text-white lg:text-4xl xl:text-5xl"
+        class="title2 mb-2 block p-4 text-center text-[1.65rem] font-bold text-white sm:text-sm lg:text-4xl xl:text-5xl"
       >
         ¡Así fue el año pasado!
       </h2>


### PR DESCRIPTION
# Corrección del título de la galería en dispositivos móviles

## ¿Qué se ha hecho en esta PR?

Se ha ajustado el tamaño de la fuente del título de la galería para evitar que en dispositivos móviles se produzca un salto de línea no deseado. Esto garantiza que la animación mantenga su fluidez y se visualice correctamente sin interrupciones.

**Arregla:** No hay issue asociado.

---

## Tipo de cambio

Marca las opciones relevantes para esta PR:

- [x] Corrección de errores (cambio no disruptivo que soluciona un problema)
- [ ] Nueva funcionalidad (cambio no disruptivo que añade una nueva funcionalidad)
- [ ] Cambio disruptivo (corrección o funcionalidad que causa que una funcionalidad existente no funcione como se espera)
- [ ] Mejora de documentación

---

## ¿Se han realizado tests automáticos?

- [ ] Sí
- [x] No

---

## ¿Cuál es el comportamiento esperado tras el cambio?

El título de la galería se mostrará correctamente en todas las pantallas sin dividirse en múltiples líneas en dispositivos móviles. Esto permite que la animación conserve su efecto de onda sin cortes o desajustes.

---

## ¿Cómo se pueden testear las características introducidas en esta PR?

Se puede comprobar visualmente en dispositivos móviles o utilizando las herramientas de desarrollo del navegador para simular distintos tamaños de pantalla.

---

## Capturas de pantalla

- Antes

https://github.com/user-attachments/assets/bedb96d9-8efe-4483-bb95-cf8df1972737


- Despues

https://github.com/user-attachments/assets/8351c024-f4b4-436d-9864-25e92e63ed01


---

## Enlaces adicionales

No hay enlaces adicionales.
