### PR TITLE
fix: gallery images disappearing on pc

### DIFF
--- a/src/sections/Gallery.astro
+++ b/src/sections/Gallery.astro
@@ -37,7 +37,7 @@ import WaveSeparator from "@/components/WaveSeparator.astro"
         galleryImages.map(({ image, alt, thumb }, index) => (
           <li
             class="-m-1 aspect-9/10 w-72 shrink-0 cursor-pointer snap-center rounded-md shadow-sm transition-transform duration-300 will-change-transform"
-            id={thumb}
+            id={thumb + 'slider'}
             data-index={index}
           >
             <Image
@@ -45,7 +45,7 @@ import WaveSeparator from "@/components/WaveSeparator.astro"
               alt={alt}
               width={950}
               height={900}
-              data-thumbID={thumb}
+              data-thumbID={thumb+ 'slider'}
               class="border-theme-blue-light h-full w-full rounded-md border border-dashed object-cover"
               loading="lazy"
             />


### PR DESCRIPTION
## ¿Qué se ha hecho en esta PR?

Se ha añadido el sufijo "slider" al thumb de las imágenes del slider en la galería para evitar errores de identificación.

---

## Tipo de cambio

Marca las opciones relevantes para esta PR:

- [X] Corrección de errores (cambio no disruptivo que soluciona un problema)
- [ ] Nueva funcionalidad (cambio no disruptivo que añade una nueva funcionalidad)
- [ ] Cambio disruptivo (corrección o funcionalidad que causa que una funcionalidad existente no funcione como se espera)
- [ ] Mejora de documentación

---

## ¿Se han realizado tests automáticos?

- [ ] Sí
- [X] No

---

## ¿Cuál es el comportamiento esperado tras el cambio?

Abrir imágenes de la galería y que al cerrarlas sigan en la lista de imágenes.

---

## ¿Cómo se pueden testear las características introducidas en esta PR?

No es necesario realizar pruebas.

---

## Capturas de pantalla

[antes.webm](https://github.com/user-attachments/assets/9d61531e-56c0-48dc-a3bc-4105fae84bee)
[despues.webm](https://github.com/user-attachments/assets/6c66a239-ce3d-49f9-b120-4a7bec891992)

---

## Enlaces adicionales

No hay enlaces adicionales.