### PR TITLE
Actualización de Header.astro

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -61,7 +61,7 @@
     </div>
   </nav>
   <dialog
-    class="transition-(display) bg-primary z-50 size-full max-h-full max-w-full translate-x-0 transition-discrete duration-300 lg:hidden starting:-translate-x-full [&:not([open])]:-translate-x-full"
+    class="bg-primary z-50 w-full max-h-[80vh] max-w-full translate-x-0 transition-discrete duration-300 lg:hidden starting:-translate-x-full [&:not([open])]:-translate-x-full"
     id="mobile-menu"
     role="dialog"
     aria-modal="true"


### PR DESCRIPTION
# Razón de este pull request

El mobile-menu ocupaba toda la pantalla en formato móvil, impidiendo visualizar el fondo y la información. Con este ajuste, ahora solo ocupa la parte superior, mejorando la experiencia visual al permitir tanto ver el fondo como el desplegable correctamente.

![Antes](https://github.com/user-attachments/assets/018e1bc5-1b4f-4c57-9d08-e1fe6ea1ddaf)
![Después](https://github.com/user-attachments/assets/054db01a-a475-4bdd-aaaa-803799a1e3fd)
