### PR TITLE
fix: Unnecessary header borders

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -210,7 +210,7 @@ import HeaderLink, { Device, Target } from "@/components/HeaderLink.astro"
   @reference "../styles/global.css";
 
   header {
-    @apply border border-b-transparent;
+    @apply border-b border-b-transparent;
     transition:
       background 0.3s,
       padding-bottom 0.2s,


### PR DESCRIPTION
## ¿Qué se ha hecho en esta PR?

Se ha quitado el borde superior, izquierdo y derecho del header y se ha cambiado por solo el border-b para mantener la transición.

**Arregla:** Bordes innecesarios

---

## Tipo de cambio

Marca las opciones relevantes para esta PR:

- [x] Corrección de errores (cambio no disruptivo que soluciona un problema)
- [ ] Nueva funcionalidad (cambio no disruptivo que añade una nueva funcionalidad)
- [ ] Cambio disruptivo (corrección o funcionalidad que causa que una funcionalidad existente no funcione como se espera)
- [ ] Mejora de documentación

---

## ¿Se han realizado tests automáticos?

- [ ] Sí
- [x] No

---

## ¿Cuál es el comportamiento esperado tras el cambio?

Elimina los bordes innecesarios en el header.

---

## ¿Cómo se pueden testear las características introducidas en esta PR?

Es visible a simple vista si te fijas bien en el header derecha, arriba e izquierda.

---

## Capturas de pantalla

<img width="241" alt="image" src="https://github.com/user-attachments/assets/c28e6b11-f2d6-4a71-9c65-26f06b68b328" />

<img width="244" alt="image" src="https://github.com/user-attachments/assets/42b9d3fe-dc1b-4100-8145-1cd17b5d6274" />


---

## Enlaces adicionales

No hay enlaces adicionales.